### PR TITLE
Removed `using namespace std` from header files and fix errors

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -7,25 +7,25 @@ stages:
   - process
 
 before_script:
-    - export USER="connector"
+  - export USER="connector"
 
 clang-format:
-    stage: pre-build
-    script:
-        - echo "**$CRONJOB**"
-        - echo "**$CI_SERVER_HOST**"
-        - cd ${CI_PROJECT_DIR}/pipeline/clang-format/
-        - ./clangformattest.sh
-          # We execute only at a schedulled pipeline that defines CRONJOB variable
-    only:
-        variables:
-            - $CRONJOB
+  stage: pre-build
+  script:
+    - echo "**$CRONJOB**"
+    - echo "**$CI_SERVER_HOST**"
+    - cd ${CI_PROJECT_DIR}/pipeline/clang-format/
+    - ./clangformattest.sh
+    # We execute only at a scheduled pipeline that defines CRONJOB variable
+  only:
+    variables:
+      - $CRONJOB
 
 Validate Library:
-    stage: pre-build
-    script:
-        - python pipeline/validateLibrary.py .
-    except:
-        variables:
-            - $CRONJOB == "YES"
+  stage: pre-build
+  script:
+    - python pipeline/validateLibrary.py .
+  except:
+    variables:
+      - $CRONJOB == "YES"
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,4 +1,4 @@
-image: lobis/root-geant4-garfieldpp:cxx14_ROOTv6-25-01_Geant4v10.4.3
+image: ghcr.io/lobis/root-geant4-garfield:rest-for-physics
 
 stages:
   - pre-build
@@ -21,7 +21,7 @@ clang-format:
         variables:
             - $CRONJOB
 
-validateLibrary:
+Validate Library:
     stage: pre-build
     script:
         - python pipeline/validateLibrary.py .

--- a/inc/TRestDetectorHitsToTrackFastProcess.h
+++ b/inc/TRestDetectorHitsToTrackFastProcess.h
@@ -12,17 +12,16 @@
 #ifndef RestCore_TRestDetectorHitsToTrackFastProcess
 #define RestCore_TRestDetectorHitsToTrackFastProcess
 
-#include <TRestEventProcess.h>
 #include <TRestDetectorHitsEvent.h>
+#include <TRestEventProcess.h>
 #include <TRestTrackEvent.h>
-
 #include <TVector3.h>
 
 class TRestDetectorHitsToTrackFastProcess : public TRestEventProcess {
    private:
 #ifndef __CINT__
-    TRestDetectorHitsEvent* fHitsEvent;    //!
-    TRestTrackEvent* fTrackEvent;  //!
+    TRestDetectorHitsEvent* fHitsEvent;  //!
+    TRestTrackEvent* fTrackEvent;        //!
 #endif
 
     void InitFromConfigFile();

--- a/inc/TRestDetectorHitsToTrackProcess.h
+++ b/inc/TRestDetectorHitsToTrackProcess.h
@@ -14,14 +14,15 @@
 
 #include <TRestDetectorHitsEvent.h>
 #include <TRestTrackEvent.h>
+
 #include "TMatrixD.h"
 #include "TRestEventProcess.h"
 
 class TRestDetectorHitsToTrackProcess : public TRestEventProcess {
    private:
 #ifndef __CINT__
-    TRestDetectorHitsEvent* fHitsEvent;    //!
-    TRestTrackEvent* fTrackEvent;  //!
+    TRestDetectorHitsEvent* fHitsEvent;  //!
+    TRestTrackEvent* fTrackEvent;        //!
 #endif
 
     void InitFromConfigFile();

--- a/inc/TRestDetectorSignalToRawSignalProcess.h
+++ b/inc/TRestDetectorSignalToRawSignalProcess.h
@@ -23,8 +23,8 @@
 #ifndef RestCore_TRestDetectorSignalToRawSignalProcess
 #define RestCore_TRestDetectorSignalToRawSignalProcess
 
-#include <TRestRawSignalEvent.h>
 #include <TRestDetectorSignalEvent.h>
+#include <TRestRawSignalEvent.h>
 
 #include "TRestEventProcess.h"
 

--- a/inc/TRestGeant4ToDetectorHitsProcess.h
+++ b/inc/TRestGeant4ToDetectorHitsProcess.h
@@ -42,10 +42,10 @@ class TRestGeant4ToDetectorHitsProcess : public TRestEventProcess {
     TRestDetectorHitsEvent* fHitsEvent;  //!
 
     /// The volume ids from the volumes selected for transfer to TRestDetectorHitsEvent
-    vector<Int_t> fVolumeId;  //!
+    std::vector<Int_t> fVolumeId;  //!
 
     /// The geometry volume names to be transferred to TRestDetectorHitsEvent
-    vector<TString> fVolumeSelection;
+    std::vector<TString> fVolumeSelection;
 
     void InitFromConfigFile();
 

--- a/inc/TRestRawReadoutAnalysisProcess.h
+++ b/inc/TRestRawReadoutAnalysisProcess.h
@@ -36,14 +36,14 @@ class TRestRawReadoutAnalysisProcess : public TRestEventProcess {
 
     void Initialize();
 
-    string fModuleCanvasSave;  //!
+    std::string fModuleCanvasSave;  //!
 
     // plots (saved directly in root file)
-    map<int, TH2D*> fModuleHitMaps;    //! [MM id, channel activity]
-    map<int, TH1D*> fModuleActivityX;  //! [MM id, channel activity]
-    map<int, TH1D*> fModuleActivityY;  //! [MM id, channel activity]
-    map<int, TH2D*> fModuleBSLSigmaX;  //! [MM id, channel activity]
-    map<int, TH2D*> fModuleBSLSigmaY;  //! [MM id, channel activity]
+    std::map<int, TH2D*> fModuleHitMaps;    //! [MM id, channel activity]
+    std::map<int, TH1D*> fModuleActivityX;  //! [MM id, channel activity]
+    std::map<int, TH1D*> fModuleActivityY;  //! [MM id, channel activity]
+    std::map<int, TH2D*> fModuleBSLSigmaX;  //! [MM id, channel activity]
+    std::map<int, TH2D*> fModuleBSLSigmaY;  //! [MM id, channel activity]
                                        //
 
    public:

--- a/inc/TRestRawReadoutAnalysisProcess.h
+++ b/inc/TRestRawReadoutAnalysisProcess.h
@@ -16,9 +16,9 @@
 
 //#include <TCanvas.h>
 
-#include <TRestDetectorReadout.h>
 #include <TRestDetectorGas.h>
 #include <TRestDetectorHitsEvent.h>
+#include <TRestDetectorReadout.h>
 #include <TRestRawSignalEvent.h>
 
 #include "TRestEventProcess.h"
@@ -44,7 +44,7 @@ class TRestRawReadoutAnalysisProcess : public TRestEventProcess {
     std::map<int, TH1D*> fModuleActivityY;  //! [MM id, channel activity]
     std::map<int, TH2D*> fModuleBSLSigmaX;  //! [MM id, channel activity]
     std::map<int, TH2D*> fModuleBSLSigmaY;  //! [MM id, channel activity]
-                                       //
+                                            //
 
    public:
     any GetInputEvent() { return fSignalEvent; }

--- a/inc/TRestRawSignalRecoverChannelsProcess.h
+++ b/inc/TRestRawSignalRecoverChannelsProcess.h
@@ -24,9 +24,8 @@
 #define RestCore_TRestRawSignalRecoverChannelsProcess
 
 #include "TRestDetectorReadout.h"
-#include "TRestRawSignalEvent.h"
-
 #include "TRestEventProcess.h"
+#include "TRestRawSignalEvent.h"
 
 //! A process allowing to recover selected channels from a TRestRawSignalEvent
 class TRestRawSignalRecoverChannelsProcess : public TRestEventProcess {

--- a/inc/TRestRawSignalRecoverChannelsProcess.h
+++ b/inc/TRestRawSignalRecoverChannelsProcess.h
@@ -60,7 +60,7 @@ class TRestRawSignalRecoverChannelsProcess : public TRestEventProcess {
     void InitProcess();
     TRestEvent* ProcessEvent(TRestEvent* eventInput);
 
-    void LoadConfig(std::string cfgFilename, string name = "");
+    void LoadConfig(std::string cfgFilename, std::string name = "");
 
     /// It prints out the process parameters stored in the metadata structure
     void PrintMetadata() {

--- a/inc/TRestRawSignalToSignalProcess.h
+++ b/inc/TRestRawSignalToSignalProcess.h
@@ -61,7 +61,7 @@ class TRestRawSignalToSignalProcess : public TRestEventProcess {
 
     TRestEvent* ProcessEvent(TRestEvent* eventInput);
 
-    void LoadConfig(std::string cfgFilename, string name = "");
+    void LoadConfig(std::string cfgFilename, std::string name = "");
 
     /// It prints out the process parameters stored in the metadata structure
     void PrintMetadata() {

--- a/inc/TRestRawSignalToSignalProcess.h
+++ b/inc/TRestRawSignalToSignalProcess.h
@@ -23,8 +23,8 @@
 #ifndef RestCore_TRestRawSignalToSignalProcess
 #define RestCore_TRestRawSignalToSignalProcess
 
-#include <TRestRawSignalEvent.h>
 #include <TRestDetectorSignalEvent.h>
+#include <TRestRawSignalEvent.h>
 
 #include "TRestEventProcess.h"
 

--- a/inc/TRestRawZeroSuppresionProcess.h
+++ b/inc/TRestRawZeroSuppresionProcess.h
@@ -26,8 +26,8 @@
 //#include <TRestDetectorGas.h>
 //#include <TRestDetectorReadout.h>
 
-#include <TRestRawSignalEvent.h>
 #include <TRestDetectorSignalEvent.h>
+#include <TRestRawSignalEvent.h>
 
 #include "TRestEventProcess.h"
 
@@ -60,8 +60,8 @@ class TRestRawZeroSuppresionProcess : public TRestEventProcess {
     /// A parameter to determine if baseline correction has been applied by a previous process
     bool fBaseLineCorrection;
 
-    /// The ADC sampling used to transform ADC units to physical time in the output TRestDetectorSignalEvent. Given in
-    /// us.
+    /// The ADC sampling used to transform ADC units to physical time in the output TRestDetectorSignalEvent.
+    /// Given in us.
     Double_t fSampling;
 
     void InitFromConfigFile();

--- a/inc/TRestTrackToDetectorHitsProcess.h
+++ b/inc/TRestTrackToDetectorHitsProcess.h
@@ -14,13 +14,14 @@
 
 #include <TRestDetectorHitsEvent.h>
 #include <TRestTrackEvent.h>
+
 #include "TRestEventProcess.h"
 
 class TRestTrackToDetectorHitsProcess : public TRestEventProcess {
    private:
 #ifndef __CINT__
-    TRestTrackEvent* fInputTrackEvent;  //!
-    TRestDetectorHitsEvent* fOutputHitsEvent;   //!
+    TRestTrackEvent* fInputTrackEvent;         //!
+    TRestDetectorHitsEvent* fOutputHitsEvent;  //!
 #endif
 
     void InitFromConfigFile();

--- a/inc/TRestTrackToDetectorHitsProcess.h
+++ b/inc/TRestTrackToDetectorHitsProcess.h
@@ -44,7 +44,7 @@ class TRestTrackToDetectorHitsProcess : public TRestEventProcess {
     void PrintMetadata() {
         BeginPrintProcess();
 
-        cout << "Track level : " << fTrackLevel << endl;
+        std::cout << "Track level : " << fTrackLevel << endl;
 
         EndPrintProcess();
     }

--- a/src/TRestDetectorHitsToTrackFastProcess.cxx
+++ b/src/TRestDetectorHitsToTrackFastProcess.cxx
@@ -55,7 +55,7 @@ void TRestDetectorHitsToTrackFastProcess::Initialize() {
     fNetOrigin = TVector3(-500, -500, -500);
     fNodes = (Int_t)(fNetSize / fCellResolution);
 
-    fHitsEvent = NULL;
+    fHitsEvent = nullptr;
     fTrackEvent = new TRestTrackEvent();
 }
 
@@ -126,7 +126,7 @@ TRestEvent* TRestDetectorHitsToTrackFastProcess::ProcessEvent(TRestEvent* evInpu
     getchar();
     */
 
-    if (fTrackEvent->GetNumberOfTracks() == 0) return NULL;
+    if (fTrackEvent->GetNumberOfTracks() == 0) return nullptr;
 
     fTrackEvent->SetLevels();
 

--- a/src/TRestDetectorHitsToTrackProcess.cxx
+++ b/src/TRestDetectorHitsToTrackProcess.cxx
@@ -50,7 +50,7 @@ void TRestDetectorHitsToTrackProcess::Initialize() {
 
     fClusterDistance = 1.;
 
-    fHitsEvent = NULL;
+    fHitsEvent = nullptr;
     fTrackEvent = new TRestTrackEvent();
 }
 
@@ -110,7 +110,7 @@ TRestEvent* TRestDetectorHitsToTrackProcess::ProcessEvent(TRestEvent* evInput) {
              << fTrackEvent->GetNumberOfTracks() << endl;
     }
 
-    if (fTrackEvent->GetNumberOfTracks() == 0) return NULL;
+    if (fTrackEvent->GetNumberOfTracks() == 0) return nullptr;
 
     if (GetVerboseLevel() >= REST_Debug) fTrackEvent->PrintOnlyTracks();
 

--- a/src/TRestDetectorSignalToRawSignalProcess.cxx
+++ b/src/TRestDetectorSignalToRawSignalProcess.cxx
@@ -186,7 +186,7 @@ void TRestDetectorSignalToRawSignalProcess::Initialize() {
     SetSectionName(this->ClassName());
     SetLibraryVersion(LIBRARY_VERSION);
 
-    fInputSignalEvent = NULL;
+    fInputSignalEvent = nullptr;
     fOutputRawSignalEvent = new TRestRawSignalEvent();
 }
 
@@ -196,7 +196,7 @@ void TRestDetectorSignalToRawSignalProcess::Initialize() {
 TRestEvent* TRestDetectorSignalToRawSignalProcess::ProcessEvent(TRestEvent* evInput) {
     fInputSignalEvent = (TRestDetectorSignalEvent*)evInput;
 
-    if (fInputSignalEvent->GetNumberOfSignals() <= 0) return NULL;
+    if (fInputSignalEvent->GetNumberOfSignals() <= 0) return nullptr;
 
     if (GetVerboseLevel() >= REST_Debug) fOutputRawSignalEvent->PrintEvent();
 

--- a/src/TRestGeant4ToDetectorHitsProcess.cxx
+++ b/src/TRestGeant4ToDetectorHitsProcess.cxx
@@ -109,7 +109,7 @@ void TRestGeant4ToDetectorHitsProcess::Initialize() {
     SetSectionName(this->ClassName());
     SetLibraryVersion(LIBRARY_VERSION);
 
-    fG4Event = NULL;
+    fG4Event = nullptr;
     fHitsEvent = new TRestDetectorHitsEvent();
 }
 

--- a/src/TRestRawReadoutAnalysisProcess.cxx
+++ b/src/TRestRawReadoutAnalysisProcess.cxx
@@ -34,19 +34,19 @@ void TRestRawReadoutAnalysisProcess::Initialize() {
     SetSectionName(this->ClassName());
     SetLibraryVersion(LIBRARY_VERSION);
 
-    fSignalEvent = NULL;
+    fSignalEvent = nullptr;
 
-    fReadout = NULL;
+    fReadout = nullptr;
 }
 
 //______________________________________________________________________________
 void TRestRawReadoutAnalysisProcess::InitProcess() {
     fReadout = GetMetadata<TRestDetectorReadout>();
-    if (fReadout != NULL) {
+    if (fReadout != nullptr) {
         auto iter = fModuleHitMaps.begin();
         while (iter != fModuleHitMaps.end()) {
             TRestDetectorReadoutModule* mod = fReadout->GetReadoutModuleWithID(iter->first);
-            if (mod == NULL) {
+            if (mod == nullptr) {
                 warning << "REST Warning(TRestRawReadoutAnalysisProcess): readout "
                            "module with id "
                         << iter->first << " not found!" << endl;
@@ -88,7 +88,7 @@ void TRestRawReadoutAnalysisProcess::InitProcess() {
 //______________________________________________________________________________
 TRestEvent* TRestRawReadoutAnalysisProcess::ProcessEvent(TRestEvent* evInput) {
     fSignalEvent = (TRestRawSignalEvent*)evInput;
-    if (fReadout != NULL) {
+    if (fReadout != nullptr) {
         Double_t firstX_id = -1.;
         Double_t firstY_id = -1.;
         Double_t firstX_t = 512.0;
@@ -193,7 +193,7 @@ TRestEvent* TRestRawReadoutAnalysisProcess::ProcessEvent(TRestEvent* evInput) {
                 modulefirstxchannel[mod1] = x;
                 modulefirstychannel[mod1] = y;
                 if (fModuleHitMaps.count(mod1) > 0) {
-                    if (fModuleHitMaps[mod1] != NULL) fModuleHitMaps[mod1]->Fill(x, y);
+                    if (fModuleHitMaps[mod1] != nullptr) fModuleHitMaps[mod1]->Fill(x, y);
                 }
                 // cout << n<<" "<<channel1 <<" "<< channel2 << endl;
                 // cout << x << " " << y << endl;
@@ -252,11 +252,11 @@ TRestEvent* TRestRawReadoutAnalysisProcess::ProcessEvent(TRestEvent* evInput) {
 
 //______________________________________________________________________________
 void TRestRawReadoutAnalysisProcess::EndProcess() {
-    if (fReadout != NULL) {
+    if (fReadout != nullptr) {
         {
             auto iter = fModuleHitMaps.begin();
             while (iter != fModuleHitMaps.end()) {
-                if (fModuleHitMaps[iter->first] != NULL) {
+                if (fModuleHitMaps[iter->first] != nullptr) {
                     TH2D* histo = fModuleHitMaps[iter->first];
                     histo->GetXaxis()->SetTitle("X Channel");
                     histo->GetYaxis()->SetTitle("Y Channel");
@@ -264,7 +264,7 @@ void TRestRawReadoutAnalysisProcess::EndProcess() {
                 }
 
                 if (fModuleCanvasSave != "none") {
-                    if (fModuleHitMaps[iter->first] != NULL) {
+                    if (fModuleHitMaps[iter->first] != nullptr) {
                         TH2D* histo = fModuleHitMaps[iter->first];
                         TCanvas* c1 =
                             new TCanvas((TString) "Can_ModuleHitMap" + ToString(iter->first),
@@ -279,7 +279,7 @@ void TRestRawReadoutAnalysisProcess::EndProcess() {
                     h0->SetStats(false);
                     h0->Reset();
 
-                    if (fModuleActivityX[iter->first] != NULL && fModuleActivityY[iter->first] != NULL) {
+                    if (fModuleActivityX[iter->first] != nullptr && fModuleActivityY[iter->first] != nullptr) {
                         TH1D* h1 = fModuleActivityX[iter->first];
                         TH1D* h2 = fModuleActivityY[iter->first];
 
@@ -307,7 +307,7 @@ void TRestRawReadoutAnalysisProcess::EndProcess() {
                         delete c1;
                     }
 
-                    if (fModuleBSLSigmaX[iter->first] != NULL && fModuleBSLSigmaY[iter->first] != NULL) {
+                    if (fModuleBSLSigmaX[iter->first] != nullptr && fModuleBSLSigmaY[iter->first] != nullptr) {
                         TH2D* h1 = fModuleBSLSigmaX[iter->first];
                         TH2D* h2 = fModuleBSLSigmaY[iter->first];
 
@@ -355,10 +355,10 @@ void TRestRawReadoutAnalysisProcess::InitFromConfigFile() {
     string moduleHist = GetParameter("modulesHist", "");
     auto histdef = Split(moduleHist, ":");
     for (int i = 0; i < histdef.size(); i++) {
-        fModuleHitMaps[StringToInteger(histdef[i])] = NULL;
-        fModuleActivityX[StringToInteger(histdef[i])] = NULL;
-        fModuleActivityY[StringToInteger(histdef[i])] = NULL;
-        fModuleBSLSigmaX[StringToInteger(histdef[i])] = NULL;
-        fModuleBSLSigmaY[StringToInteger(histdef[i])] = NULL;
+        fModuleHitMaps[StringToInteger(histdef[i])] = nullptr;
+        fModuleActivityX[StringToInteger(histdef[i])] = nullptr;
+        fModuleActivityY[StringToInteger(histdef[i])] = nullptr;
+        fModuleBSLSigmaX[StringToInteger(histdef[i])] = nullptr;
+        fModuleBSLSigmaY[StringToInteger(histdef[i])] = nullptr;
     }
 }

--- a/src/TRestRawSignalRecoverChannelsProcess.cxx
+++ b/src/TRestRawSignalRecoverChannelsProcess.cxx
@@ -116,7 +116,7 @@ void TRestRawSignalRecoverChannelsProcess::Initialize() {
     SetSectionName(this->ClassName());
     SetLibraryVersion(LIBRARY_VERSION);
 
-    fInputSignalEvent = NULL;
+    fInputSignalEvent = nullptr;
     fOutputSignalEvent = new TRestRawSignalEvent();
 }
 
@@ -144,7 +144,7 @@ void TRestRawSignalRecoverChannelsProcess::LoadConfig(string cfgFilename, string
 void TRestRawSignalRecoverChannelsProcess::InitProcess() {
     fReadout = GetMetadata<TRestDetectorReadout>();
 
-    if (fReadout == NULL) {
+    if (fReadout == nullptr) {
         cout << "REST ERRORRRR : Readout has not been initialized" << endl;
         exit(-1);
     }
@@ -177,7 +177,7 @@ TRestEvent* TRestRawSignalRecoverChannelsProcess::ProcessEvent(TRestEvent* evInp
         TRestRawSignal* leftSgnl = fInputSignalEvent->GetSignalById(idL);
         TRestRawSignal* rightSgnl = fInputSignalEvent->GetSignalById(idR);
 
-        if (leftSgnl == NULL && rightSgnl == NULL) continue;
+        if (leftSgnl == nullptr && rightSgnl == nullptr) continue;
 
         TRestRawSignal* recoveredSignal = new TRestRawSignal();
         recoveredSignal->SetID(fChannelIds[x]);
@@ -185,11 +185,11 @@ TRestEvent* TRestRawSignalRecoverChannelsProcess::ProcessEvent(TRestEvent* evInp
         Short_t dataRecovered[nPoints];
         for (int n = 0; n < nPoints; n++) dataRecovered[n] = 0;
 
-        if (leftSgnl != NULL) {
+        if (leftSgnl != nullptr) {
             for (int n = 0; n < nPoints; n++) dataRecovered[n] = leftSgnl->GetData(n);
         }
 
-        if (rightSgnl != NULL) {
+        if (rightSgnl != nullptr) {
             for (int n = 0; n < nPoints; n++) dataRecovered[n] += rightSgnl->GetData(n);
         }
 
@@ -200,7 +200,7 @@ TRestEvent* TRestRawSignalRecoverChannelsProcess::ProcessEvent(TRestEvent* evInp
         delete recoveredSignal;
         /*
         cout << "Channel recovered!! " << endl;
-        if( leftSgnl != NULL && rightSgnl != NULL )
+        if( leftSgnl != nullptr && rightSgnl != nullptr )
             for( int n = 0; n < nPoints; n++ )
                 cout << "Sample " << n << " : " << leftSgnl->GetData(n) << " + " <<
         rightSgnl->GetData(n) << " = " << recoveredSignal->GetData(n) << endl;

--- a/src/TRestRawSignalToSignalProcess.cxx
+++ b/src/TRestRawSignalToSignalProcess.cxx
@@ -135,7 +135,7 @@ void TRestRawSignalToSignalProcess::Initialize() {
     SetSectionName(this->ClassName());
     SetLibraryVersion(LIBRARY_VERSION);
 
-    fInputSignalEvent = NULL;
+    fInputSignalEvent = nullptr;
     fOutputSignalEvent = new TRestDetectorSignalEvent();
 }
 

--- a/src/TRestRawZeroSuppresionProcess.cxx
+++ b/src/TRestRawZeroSuppresionProcess.cxx
@@ -164,7 +164,7 @@ void TRestRawZeroSuppresionProcess::Initialize() {
     SetSectionName(this->ClassName());
     SetLibraryVersion(LIBRARY_VERSION);
 
-    fRawSignalEvent = NULL;
+    fRawSignalEvent = nullptr;
     fSignalEvent = new TRestDetectorSignalEvent();
 }
 
@@ -268,7 +268,7 @@ TRestEvent* TRestRawZeroSuppresionProcess::ProcessEvent(TRestEvent* evInput) {
     debug << "TRestRawZeroSuppresionProcess. Signals rejected : " << rejectedSignal << endl;
     debug << "TRestRawZeroSuppresionProcess. Threshold integral : " << totalIntegral << endl;
 
-    if (fSignalEvent->GetNumberOfSignals() <= 0) return NULL;
+    if (fSignalEvent->GetNumberOfSignals() <= 0) return nullptr;
 
     return fSignalEvent;
 }

--- a/src/TRestRawZeroSuppresionProcess.cxx
+++ b/src/TRestRawZeroSuppresionProcess.cxx
@@ -89,6 +89,7 @@
 #include "TRestRawZeroSuppresionProcess.h"
 
 #include <numeric>
+
 using namespace std;
 
 const double cmTomm = 10.;

--- a/src/TRestRawZeroSuppresionProcess.cxx
+++ b/src/TRestRawZeroSuppresionProcess.cxx
@@ -87,6 +87,7 @@
 ///
 
 #include "TRestRawZeroSuppresionProcess.h"
+
 #include <numeric>
 using namespace std;
 

--- a/src/TRestTrackToDetectorHitsProcess.cxx
+++ b/src/TRestTrackToDetectorHitsProcess.cxx
@@ -37,7 +37,7 @@ void TRestTrackToDetectorHitsProcess::Initialize() {
     SetSectionName(this->ClassName());
     SetLibraryVersion(LIBRARY_VERSION);
 
-    fInputTrackEvent = NULL;
+    fInputTrackEvent = nullptr;
     fOutputHitsEvent = new TRestDetectorHitsEvent();
 }
 


### PR DESCRIPTION
![lobis](https://badgen.net/badge/PR%20submitted%20by%3A/lobis/blue) ![82](https://badgen.net/badge/Size/82/orange) [![](https://gitlab.cern.ch/rest-for-physics/connectorslib/badges/lobis-remove-namespace-std-from-headers/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/connectorslib/-/commits/lobis-remove-namespace-std-from-headers)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Needed for https://github.com/rest-for-physics/framework/pull/168. Read PR for additional info.