### PR TITLE
Renaming endl to RESTendl and other logger functions

### DIFF
--- a/inc/TRestDetectorHitsToTrackFastProcess.h
+++ b/inc/TRestDetectorHitsToTrackFastProcess.h
@@ -51,11 +51,11 @@ class TRestDetectorHitsToTrackFastProcess : public TRestEventProcess {
     void PrintMetadata() override {
         BeginPrintProcess();
 
-        metadata << " Cell resolution : " << fCellResolution << " mm " << endl;
-        metadata << " Net size : " << fNetSize << " mm " << endl;
-        metadata << " Net origin : ( " << fNetOrigin.X() << " , " << fNetOrigin.Y() << " , " << fNetOrigin.Z()
-                 << " ) mm " << endl;
-        metadata << " Number of nodes (per axis) : " << fNodes << endl;
+        RESTMetadata << " Cell resolution : " << fCellResolution << " mm " << RESTendl;
+        RESTMetadata << " Net size : " << fNetSize << " mm " << RESTendl;
+        RESTMetadata << " Net origin : ( " << fNetOrigin.X() << " , " << fNetOrigin.Y() << " , " << fNetOrigin.Z()
+                 << " ) mm " << RESTendl;
+        RESTMetadata << " Number of nodes (per axis) : " << fNodes << RESTendl;
 
         EndPrintProcess();
     }

--- a/inc/TRestDetectorHitsToTrackProcess.h
+++ b/inc/TRestDetectorHitsToTrackProcess.h
@@ -54,7 +54,7 @@ class TRestDetectorHitsToTrackProcess : public TRestEventProcess {
     void PrintMetadata() override {
         BeginPrintProcess();
 
-        metadata << " cluster-distance : " << fClusterDistance << " mm " << endl;
+        RESTMetadata << " cluster-distance : " << fClusterDistance << " mm " << RESTendl;
 
         EndPrintProcess();
     }

--- a/inc/TRestDetectorSignalToRawSignalProcess.h
+++ b/inc/TRestDetectorSignalToRawSignalProcess.h
@@ -90,11 +90,11 @@ class TRestDetectorSignalToRawSignalProcess : public TRestEventProcess {
     void PrintMetadata() override {
         BeginPrintProcess();
 
-        metadata << "Sampling time : " << fSampling << " us" << endl;
-        metadata << "Points per channel : " << fNPoints << endl;
-        metadata << "Trigger mode : " << fTriggerMode << endl;
-        metadata << "Trigger delay : " << fTriggerDelay << " time units" << endl;
-        metadata << "ADC gain : " << fGain << endl;
+        RESTMetadata << "Sampling time : " << fSampling << " us" << RESTendl;
+        RESTMetadata << "Points per channel : " << fNPoints << RESTendl;
+        RESTMetadata << "Trigger mode : " << fTriggerMode << RESTendl;
+        RESTMetadata << "Trigger delay : " << fTriggerDelay << " time units" << RESTendl;
+        RESTMetadata << "ADC gain : " << fGain << RESTendl;
 
         EndPrintProcess();
     }

--- a/inc/TRestRawReadoutAnalysisProcess.h
+++ b/inc/TRestRawReadoutAnalysisProcess.h
@@ -57,15 +57,15 @@ class TRestRawReadoutAnalysisProcess : public TRestEventProcess {
     void PrintMetadata() override {
         BeginPrintProcess();
 
-        metadata << "channel activity and hitmap histograms required for module: ";
+        RESTMetadata << "channel activity and hitmap histograms required for module: ";
         auto iter2 = fModuleHitMaps.begin();
         while (iter2 != fModuleHitMaps.end()) {
-            metadata << iter2->first << ", ";
+            RESTMetadata << iter2->first << ", ";
             iter2++;
         }
-        metadata << endl;
+        RESTMetadata << RESTendl;
 
-        metadata << "path for output plots: " << fModuleCanvasSave << endl;
+        RESTMetadata << "path for output plots: " << fModuleCanvasSave << RESTendl;
 
         EndPrintProcess();
     }

--- a/inc/TRestRawToDetectorSignalProcess.h
+++ b/inc/TRestRawToDetectorSignalProcess.h
@@ -85,22 +85,22 @@ class TRestRawToDetectorSignalProcess : public TRestEventProcess {
     void PrintMetadata() override {
         BeginPrintProcess();
 
-        metadata << "Sampling time : " << fSampling << " us" << endl;
-        metadata << "Trigger starts : " << fTriggerStarts << " us" << endl;
-        metadata << "Gain : " << fGain << endl;
+        RESTMetadata << "Sampling time : " << fSampling << " us" << RESTendl;
+        RESTMetadata << "Trigger starts : " << fTriggerStarts << " us" << RESTendl;
+        RESTMetadata << "Gain : " << fGain << RESTendl;
 
         if (fZeroSuppression) {
-            metadata << "Base line range definition : ( " << fBaseLineRange.X() << " , " << fBaseLineRange.Y()
-                     << " ) " << endl;
-            metadata << "Integral range : ( " << fIntegralRange.X() << " , " << fIntegralRange.Y() << " ) "
-                     << endl;
-            metadata << "Point Threshold : " << fPointThreshold << " sigmas" << endl;
-            metadata << "Signal threshold : " << fSignalThreshold << " sigmas" << endl;
-            metadata << "Number of points over threshold : " << fNPointsOverThreshold << endl;
+            RESTMetadata << "Base line range definition : ( " << fBaseLineRange.X() << " , " << fBaseLineRange.Y()
+                     << " ) " << RESTendl;
+            RESTMetadata << "Integral range : ( " << fIntegralRange.X() << " , " << fIntegralRange.Y() << " ) "
+                     << RESTendl;
+            RESTMetadata << "Point Threshold : " << fPointThreshold << " sigmas" << RESTendl;
+            RESTMetadata << "Signal threshold : " << fSignalThreshold << " sigmas" << RESTendl;
+            RESTMetadata << "Number of points over threshold : " << fNPointsOverThreshold << RESTendl;
         }
 
         if (fBaseLineCorrection)
-            metadata << "BaseLine correction is enabled for TRestRawSignalAnalysisProcess" << endl;
+            RESTMetadata << "BaseLine correction is enabled for TRestRawSignalAnalysisProcess" << RESTendl;
 
         EndPrintProcess();
     }

--- a/inc/TRestTrackToDetectorHitsProcess.h
+++ b/inc/TRestTrackToDetectorHitsProcess.h
@@ -45,7 +45,7 @@ class TRestTrackToDetectorHitsProcess : public TRestEventProcess {
     void PrintMetadata() override {
         BeginPrintProcess();
 
-        std::cout << "Track level : " << fTrackLevel << endl;
+        std::cout << "Track level : " << fTrackLevel << std::endl;
 
         EndPrintProcess();
     }

--- a/src/TRestDetectorHitsToTrackProcess.cxx
+++ b/src/TRestDetectorHitsToTrackProcess.cxx
@@ -125,32 +125,32 @@ TRestEvent* TRestDetectorHitsToTrackProcess::ProcessEvent(TRestEvent* inputEvent
     fHitsEvent = (TRestDetectorHitsEvent*)inputEvent;
     fTrackEvent->SetEventInfo(fHitsEvent);
 
-    if (GetVerboseLevel() >= REST_Debug)
+    if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Debug)
         cout << "TResDetectorHitsToTrackProcess : nHits " << fHitsEvent->GetNumberOfHits() << endl;
 
     TRestHits* xzHits = fHitsEvent->GetXZHits();
 
-    if (GetVerboseLevel() >= REST_Debug)
+    if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Debug)
         cout << "TRestDetectorHitsToTrackProcess : Number of xzHits : " << xzHits->GetNumberOfHits() << endl;
     Int_t xTracks = FindTracks(xzHits);
 
     fTrackEvent->SetNumberOfXTracks(xTracks);
 
     TRestHits* yzHits = fHitsEvent->GetYZHits();
-    if (GetVerboseLevel() >= REST_Debug)
+    if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Debug)
         cout << "TRestDetectorHitsToTrackProcess : Number of yzHits : " << yzHits->GetNumberOfHits() << endl;
     Int_t yTracks = FindTracks(yzHits);
 
     fTrackEvent->SetNumberOfYTracks(yTracks);
 
     TRestHits* xyzHits = fHitsEvent->GetXYZHits();
-    if (GetVerboseLevel() >= REST_Debug)
+    if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Debug)
         cout << "TRestDetectorHitsToTrackProcess : Number of xyzHits : " << xyzHits->GetNumberOfHits()
              << endl;
 
     FindTracks(xyzHits);
 
-    if (GetVerboseLevel() >= REST_Debug) {
+    if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Debug) {
         cout << "TRestDetectorHitsToTrackProcess. X tracks : " << xTracks << "  Y tracks : " << yTracks
              << endl;
         cout << "TRestDetectorHitsToTrackProcess. Total number of tracks : "
@@ -159,7 +159,7 @@ TRestEvent* TRestDetectorHitsToTrackProcess::ProcessEvent(TRestEvent* inputEvent
 
     if (fTrackEvent->GetNumberOfTracks() == 0) return nullptr;
 
-    if (GetVerboseLevel() >= REST_Debug) fTrackEvent->PrintOnlyTracks();
+    if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Debug) fTrackEvent->PrintOnlyTracks();
 
     fTrackEvent->SetLevels();
 
@@ -173,7 +173,7 @@ TRestEvent* TRestDetectorHitsToTrackProcess::ProcessEvent(TRestEvent* inputEvent
 /// \return It returns the number of tracks found
 ///
 Int_t TRestDetectorHitsToTrackProcess::FindTracks(TRestHits* hits) {
-    if (GetVerboseLevel() >= REST_Extreme) hits->PrintHits();
+    if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Extreme) hits->PrintHits();
     Int_t nTracksFound = 0;
     vector<Int_t> Q;  // list of points (hits) that need to be checked
     vector<Int_t> P;  // list of neighbours within a radious fClusterDistance
@@ -248,7 +248,7 @@ Int_t TRestDetectorHitsToTrackProcess::FindTracks(TRestHits* hits) {
         track->SetVolumeHits(volHit);
         volHit.RemoveHits();
 
-        debug << "Adding track : id=" << track->GetTrackID() << " parent : " << track->GetParentID() << endl;
+        RESTDebug << "Adding track : id=" << track->GetTrackID() << " parent : " << track->GetParentID() << RESTendl;
         fTrackEvent->AddTrack(track);
         nTracksFound++;
 

--- a/src/TRestDetectorSignalToRawSignalProcess.cxx
+++ b/src/TRestDetectorSignalToRawSignalProcess.cxx
@@ -183,7 +183,7 @@ TRestEvent* TRestDetectorSignalToRawSignalProcess::ProcessEvent(TRestEvent* inpu
 
     if (fInputSignalEvent->GetNumberOfSignals() <= 0) return nullptr;
 
-    if (GetVerboseLevel() >= REST_Debug) fOutputRawSignalEvent->PrintEvent();
+    if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Debug) fOutputRawSignalEvent->PrintEvent();
 
     fOutputRawSignalEvent->SetID(fInputSignalEvent->GetID());
     fOutputRawSignalEvent->SetSubID(fInputSignalEvent->GetSubID());
@@ -209,7 +209,7 @@ TRestEvent* TRestDetectorSignalToRawSignalProcess::ProcessEvent(TRestEvent* inpu
             }
         }
     } else {
-        if (GetVerboseLevel() >= REST_Warning) {
+        if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Warning) {
             cout << "REST WARNING. TRestDetectorSignalToRawSignalProcess. fTriggerMode not "
                     "recognized!"
                  << endl;
@@ -223,7 +223,7 @@ TRestEvent* TRestDetectorSignalToRawSignalProcess::ProcessEvent(TRestEvent* inpu
     }
 
     if (std::isnan(tStart)) {
-        if (GetVerboseLevel() >= REST_Warning) {
+        if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Warning) {
             cout << endl;
             cout << "REST WARNING. TRestDetectorSignalToRawSignalProcess. tStart was not "
                     "defined."
@@ -235,7 +235,7 @@ TRestEvent* TRestDetectorSignalToRawSignalProcess::ProcessEvent(TRestEvent* inpu
         tEnd = fNPoints * fSampling;
     }
 
-    if (GetVerboseLevel() >= REST_Debug) {
+    if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Debug) {
         cout << "tStart : " << tStart << " us " << endl;
         cout << "tEnd : " << tEnd << " us " << endl;
     }
@@ -251,25 +251,25 @@ TRestEvent* TRestDetectorSignalToRawSignalProcess::ProcessEvent(TRestEvent* inpu
             Double_t t = sgnl->GetTime(m);
             Double_t d = sgnl->GetData(m);
 
-            if (GetVerboseLevel() >= REST_Debug && n < 3 && m < 5)
+            if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Debug && n < 3 && m < 5)
                 cout << "Signal : " << n << " Sample : " << m << " T : " << t << " Data : " << d << endl;
 
             if (t > tStart && t < tEnd) {
                 // convert physical time (in us) to timeBin
                 Int_t timeBin = (Int_t)round((t - tStart) / fSampling);
 
-                if (GetVerboseLevel() >= REST_Warning)
+                if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Warning)
                     if (timeBin < 0 || timeBin > fNPoints) {
                         cout << "Time bin out of range!!! bin value : " << timeBin << endl;
                         timeBin = 0;
                     }
 
-                debug << "Adding data : " << sgnl->GetData(m) << " to Time Bin : " << timeBin << endl;
+                RESTDebug << "Adding data : " << sgnl->GetData(m) << " to Time Bin : " << timeBin << RESTendl;
                 sData[timeBin] += fGain * sgnl->GetData(m);
             }
         }
 
-        if (GetVerboseLevel() >= REST_Warning)
+        if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Warning)
             for (int x = 0; x < fNPoints; x++)
                 if (sData[x] < -32768. || sData[x] > 32768.)
                     cout << "REST Warning : data is outside short range : " << sData[x] << endl;
@@ -283,13 +283,13 @@ TRestEvent* TRestDetectorSignalToRawSignalProcess::ProcessEvent(TRestEvent* inpu
             rSgnl.AddPoint(value);
         }
 
-        if (GetVerboseLevel() >= REST_Debug) rSgnl.Print();
-        debug << "Adding signal to raw signal event" << endl;
+        if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Debug) rSgnl.Print();
+        RESTDebug << "Adding signal to raw signal event" << RESTendl;
         fOutputRawSignalEvent->AddSignal(rSgnl);
     }
 
-    debug << "TRestDetectorSignalToRawSignalProcess. Returning event with N signals "
-          << fOutputRawSignalEvent->GetNumberOfSignals() << endl;
+    RESTDebug << "TRestDetectorSignalToRawSignalProcess. Returning event with N signals "
+          << fOutputRawSignalEvent->GetNumberOfSignals() << RESTendl;
 
     return fOutputRawSignalEvent;
 }

--- a/src/TRestGeant4ToDetectorHitsProcess.cxx
+++ b/src/TRestGeant4ToDetectorHitsProcess.cxx
@@ -140,44 +140,44 @@ void TRestGeant4ToDetectorHitsProcess::InitProcess() {
     for (unsigned int n = 0; n < fVolumeSelection.size(); n++) {
         if (fG4Metadata->GetActiveVolumeID(fVolumeSelection[n]) >= 0)
             fVolumeId.push_back(fG4Metadata->GetActiveVolumeID(fVolumeSelection[n]));
-        else if (GetVerboseLevel() >= REST_Warning)
+        else if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Warning)
             cout << "TRestGeant4ToDetectorHitsProcess. volume name : " << fVolumeSelection[n]
                  << " not found and will not be added." << endl;
     }
 
     /* {{{ Debug output */
-    debug << "Active volumes available in TRestGeant4Metadata" << endl;
-    debug << "-------------------------------------------" << endl;
+    RESTDebug << "Active volumes available in TRestGeant4Metadata" << RESTendl;
+    RESTDebug << "-------------------------------------------" << RESTendl;
     for (int n = 0; n < fG4Metadata->GetNumberOfActiveVolumes(); n++)
-        debug << "Volume id : " << n << " name : " << fG4Metadata->GetActiveVolumeName(n) << endl;
-    debug << endl;
+        RESTDebug << "Volume id : " << n << " name : " << fG4Metadata->GetActiveVolumeName(n) << RESTendl;
+    RESTDebug << RESTendl;
 
-    debug << "TRestGeant4HitsProcess volumes enabled in RML : ";
-    debug << "-------------------------------------------" << endl;
+    RESTDebug << "TRestGeant4HitsProcess volumes enabled in RML : ";
+    RESTDebug << "-------------------------------------------" << RESTendl;
     if (fVolumeSelection.size() == 0)
-        debug << "all" << endl;
+        RESTDebug << "all" << RESTendl;
     else {
         for (int n = 0; n < fVolumeSelection.size(); n++) {
-            debug << "" << endl;
-            debug << " - " << fVolumeSelection[n] << endl;
+            RESTDebug << "" << RESTendl;
+            RESTDebug << " - " << fVolumeSelection[n] << RESTendl;
         }
-        debug << " " << endl;
+        RESTDebug << " " << RESTendl;
     }
 
     if (fVolumeSelection.size() > 0 && fVolumeSelection.size() != fVolumeId.size())
-        warning << "TRestGeant4ToDetectorHitsProcess. Not all volumes were properly identified!" << endl;
+        RESTWarning << "TRestGeant4ToDetectorHitsProcess. Not all volumes were properly identified!" << RESTendl;
 
     if (fVolumeId.size() > 0) {
-        debug << "TRestGeant4HitsProcess volumes identified : ";
-        debug << "---------------------------------------" << endl;
+        RESTDebug << "TRestGeant4HitsProcess volumes identified : ";
+        RESTDebug << "---------------------------------------" << RESTendl;
         if (fVolumeSelection.size() == 0)
-            debug << "all" << endl;
+            RESTDebug << "all" << RESTendl;
         else
             for (int n = 0; n < fVolumeSelection.size(); n++) {
-                debug << "" << endl;
-                debug << " - " << fVolumeSelection[n] << endl;
+                RESTDebug << "" << RESTendl;
+                RESTDebug << " - " << fVolumeSelection[n] << RESTendl;
             }
-        debug << " " << endl;
+        RESTDebug << " " << RESTendl;
     }
     /* }}} */
 }
@@ -188,7 +188,7 @@ void TRestGeant4ToDetectorHitsProcess::InitProcess() {
 TRestEvent* TRestGeant4ToDetectorHitsProcess::ProcessEvent(TRestEvent* inputEvent) {
     fG4Event = (TRestGeant4Event*)inputEvent;
 
-    if (GetVerboseLevel() >= REST_Extreme) {
+    if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Extreme) {
         cout << "------ TRestGeant4ToDetectorHitsProcess --- Printing Input Event --- START ----" << endl;
         fG4Event->PrintEvent();
         cout << "------ TRestGeant4ToDetectorHitsProcess --- Printing Input Event ---- END ----" << endl;
@@ -219,7 +219,7 @@ TRestEvent* TRestGeant4ToDetectorHitsProcess::ProcessEvent(TRestEvent* inputEven
         }
     }
 
-    if (GetVerboseLevel() >= REST_Debug) {
+    if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Debug) {
         cout << "TRestGeant4ToDetectorHitsProcess. Hits added : " << fHitsEvent->GetNumberOfHits() << endl;
         cout << "TRestGeant4ToDetectorHitsProcess. Hits total energy : " << fHitsEvent->GetEnergy() << endl;
     }
@@ -246,7 +246,7 @@ void TRestGeant4ToDetectorHitsProcess::PrintMetadata() {
     BeginPrintProcess();
 
     for (unsigned int n = 0; n < fVolumeSelection.size(); n++)
-        metadata << "Volume added : " << fVolumeSelection[n] << endl;
+        RESTMetadata << "Volume added : " << fVolumeSelection[n] << RESTendl;
 
     EndPrintProcess();
 }

--- a/src/TRestRawReadoutAnalysisProcess.cxx
+++ b/src/TRestRawReadoutAnalysisProcess.cxx
@@ -43,9 +43,9 @@ void TRestRawReadoutAnalysisProcess::InitProcess() {
         while (iter != fModuleHitMaps.end()) {
             TRestDetectorReadoutModule* mod = fReadout->GetReadoutModuleWithID(iter->first);
             if (mod == nullptr) {
-                warning << "REST Warning(TRestRawReadoutAnalysisProcess): readout "
+                RESTWarning << "REST Warning(TRestRawReadoutAnalysisProcess): readout "
                            "module with id "
-                        << iter->first << " not found!" << endl;
+                        << iter->first << " not found!" << RESTendl;
             } else {
                 fModuleHitMaps[iter->first] =
                     new TH2D((TString) "Hitmap_M" + ToString(iter->first),
@@ -195,11 +195,11 @@ TRestEvent* TRestRawReadoutAnalysisProcess::ProcessEvent(TRestEvent* inputEvent)
                 // cout << fReadout->GetX(firstX_id) << " " << fReadout->GetY(firstY_id)
                 // << endl; cout << endl;
 
-                debug << "TRestRawReadoutAnalysisProcess. Adding point to hitmap of "
+                RESTDebug << "TRestRawReadoutAnalysisProcess. Adding point to hitmap of "
                          "module : "
-                      << mod1 << endl;
-                debug << "Position on module(X, Y) : (" << x << ", " << y << ")" << endl;
-                debug << "Absolute position:(X, Y) : (" << firstx << ", " << firsty << ")" << endl;
+                      << mod1 << RESTendl;
+                RESTDebug << "Position on module(X, Y) : (" << x << ", " << y << ")" << RESTendl;
+                RESTDebug << "Absolute position:(X, Y) : (" << firstx << ", " << firsty << ")" << RESTendl;
             }
         }
         this->SetObservableValue("ModuleFirstX", modulefirstxchannel);

--- a/src/TRestTrackToDetectorHitsProcess.cxx
+++ b/src/TRestTrackToDetectorHitsProcess.cxx
@@ -48,7 +48,7 @@ void TRestTrackToDetectorHitsProcess::InitProcess() {}
 TRestEvent* TRestTrackToDetectorHitsProcess::ProcessEvent(TRestEvent* inputEvent) {
     fInputTrackEvent = (TRestTrackEvent*)inputEvent;
 
-    if (this->GetVerboseLevel() >= REST_Debug) fInputTrackEvent->PrintOnlyTracks();
+    if (this->GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Debug) fInputTrackEvent->PrintOnlyTracks();
 
     for (int n = 0; n < fInputTrackEvent->GetNumberOfTracks(); n++)
         if (fInputTrackEvent->GetLevel(n) == fTrackLevel) {


### PR DESCRIPTION
![juanangp](https://badgen.net/badge/PR%20submitted%20by%3A/juanangp/blue) ![Ok: 75](https://badgen.net/badge/PR%20Size/Ok%3A%2075/green) [![](https://gitlab.cern.ch/rest-for-physics/framework/badges/RESTendl/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/framework/-/commits/RESTendl)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Related with https://github.com/rest-for-physics/framework/pull/225:
- Renamed custom `endl` to `RESTendl`
- Renamed other logger functions
  - `info` --> `RESTInfo`  
  - `debug` --> `RESTDebug`
  - `essential` --> `RESTEssential`
  - `warning` --> `RESTWarning`
  - `fout` --> `RESTcout`
  - `ferr` --> `RESTError`