### PR TITLE
replaced dynamic length array initializaion

### DIFF
--- a/src/TRestDetectorHitsToTrackFastProcess.cxx
+++ b/src/TRestDetectorHitsToTrackFastProcess.cxx
@@ -135,8 +135,8 @@ Int_t TRestDetectorHitsToTrackFastProcess::FindTracks(TRestHits* hits) {
 
     Int_t nTracksFound = mesh->GetNumberOfGroups();
 
-    TRestTrack track[nTracksFound];
-    TRestVolumeHits volHit[nTracksFound];
+    vector<TRestTrack> track(nTracksFound);
+    vector<TRestVolumeHits> volHit(nTracksFound);
 
     double nan = numeric_limits<double>::quiet_NaN();
     for (int h = 0; h < hits->GetNumberOfHits(); h++) {

--- a/src/TRestDetectorSignalToRawSignalProcess.cxx
+++ b/src/TRestDetectorSignalToRawSignalProcess.cxx
@@ -241,7 +241,7 @@ TRestEvent* TRestDetectorSignalToRawSignalProcess::ProcessEvent(TRestEvent* inpu
     }
 
     for (int n = 0; n < fInputSignalEvent->GetNumberOfSignals(); n++) {
-        Double_t sData[fNPoints];
+        vector<Double_t> sData(fNPoints);
         for (int i = 0; i < fNPoints; i++) sData[i] = 0;
 
         TRestDetectorSignal* sgnl = fInputSignalEvent->GetSignal(n);


### PR DESCRIPTION
![nkx111](https://badgen.net/badge/PR%20submitted%20by%3A/nkx111/blue) ![Ok: 3](https://badgen.net/badge/PR%20Size/Ok%3A%203/green) [![](https://gitlab.cern.ch/rest-for-physics/framework/badges/windows-compile/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/framework/-/commits/windows-compile)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Related to https://github.com/rest-for-physics/framework/pull/231. Array initialization with dynamic length is not available for msvc. Changed to vector. e.g. `Double_t x[nHits];` --> `vector<Double_t> x(nHits);`