### PR TITLE
Adding connectorslib github pipeline

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -1,0 +1,49 @@
+name: Validation
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+  release:
+
+  workflow_dispatch:
+
+env:
+  CMAKE_BUILD_TYPE: Release
+  REST_PATH: /rest/connectorslib/install
+  BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  framework-validation:
+    uses: rest-for-physics/framework/.github/workflows/validation.yml@master
+  
+  libCheck:
+    name: Validate library
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/lobis/root-geant4-garfield:rest-for-physics-dev
+    steps:
+      - uses: actions/checkout@v3
+      - run:  python3 pipeline/validateLibrary.py .
+
+  build-connectorslib:
+    name: Build only connectorslib
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/lobis/root-geant4-garfield:rest-for-physics-dev
+    steps:
+      - uses: actions/checkout@v3
+      - name: Build and install
+        uses: rest-for-physics/framework/.github/actions/build@master
+        with:
+          cmake-flags: "-DCMAKE_INSTALL_PREFIX=${{ env.REST_PATH }} -DCMAKE_BUILD_TYPE=${{ env.CMAKE_BUILD_TYPE }} -DREST_WELCOME=ON -DRESTLIB_CONNECTORSK=ON"
+          branch: ${{ env.BRANCH_NAME }}
+      - name: Load REST libraries
+        run: |
+          source ${{ env.REST_PATH }}/thisREST.sh
+          restRoot -b -q

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Build and install
         uses: rest-for-physics/framework/.github/actions/build@master
         with:
-          cmake-flags: "-DCMAKE_INSTALL_PREFIX=${{ env.REST_PATH }} -DCMAKE_BUILD_TYPE=${{ env.CMAKE_BUILD_TYPE }} -DREST_WELCOME=ON -DRESTLIB_CONNECTORSK=ON"
+          cmake-flags: "-DCMAKE_INSTALL_PREFIX=${{ env.REST_PATH }} -DCMAKE_BUILD_TYPE=${{ env.CMAKE_BUILD_TYPE }} -DREST_WELCOME=ON -DRESTLIB_CONNECTORS=ON"
           branch: ${{ env.BRANCH_NAME }}
       - name: Load REST libraries
         run: |

--- a/pipeline/validateLibrary.py
+++ b/pipeline/validateLibrary.py
@@ -14,9 +14,9 @@ import subprocess
 
 
 def validateClass(className):
-    print ""
-    print "++++ Validating class : " + className
-    with open(className, 'r') as file:
+    print ("")
+    print ("++++ Validating class : " + className)
+    with open(className, 'r', encoding="utf-8") as file:
         data = file.read()
 
         data = data[data.find("::Initialize"):]
@@ -26,7 +26,7 @@ def validateClass(className):
         #print (data)
         #print data.find("SETLIBRARYVERSION(LIBRARY_VERSION);")
         if data.find("SETLIBRARYVERSION(LIBRARY_VERSION);") >= 0:
-            print "OK"
+            print ("OK")
             return
         else:
             print( "Problem found at class : " + className )
@@ -48,7 +48,7 @@ def getObservablePositions(data):
            break
 
         name = data[pos1:pos2]
-        if(not obsposes.has_key(name)):
+        if(not name in obsposes):
             obsposes[name] = pos1
 
         pos = pos2 + 1
@@ -74,7 +74,7 @@ def getMethodDefinition(text):
                 counter = counter - 1
                 start = pos2 + 1
         elif pos1 != -1:
-                print "Big error!!"
+                print ("Big error!!")
         else:
                 counter = counter - 1
                 start = pos2 + 1
@@ -154,13 +154,13 @@ for r, d, f in os.walk(sys.argv[1]):
             validate = 0
             if '.cxx' in file:
 #                print ( file )
-                with open(os.path.join(r, file)) as fin:
+                with open(os.path.join(r, file), encoding="utf-8") as fin:
                     if '::InitFromConfigFile' in fin.read():
                         validate = 1
-                with open(os.path.join(r, file)) as fin:
+                with open(os.path.join(r, file), encoding="utf-8") as fin:
                     if '::LoadDefaultConfig' in fin.read():
                         validate = 1
-                with open(os.path.join(r, file)) as fin:
+                with open(os.path.join(r, file), encoding="utf-8") as fin:
                     if '::Initialize' in fin.read():
                         validate = validate + 1
             if validate == 2:


### PR DESCRIPTION
![juanangp](https://badgen.net/badge/PR%20submitted%20by%3A/juanangp/blue) ![Ok: 58](https://badgen.net/badge/PR%20Size/Ok%3A%2058/green) [![](https://gitlab.cern.ch/rest-for-physics/framework/badges/master/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/framework/-/commits/master)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Added github pipeline to connectorslib:

 - Expands gitlab pipeline (only library validation was performed), now stand alone build of connectorslib is performed
 - Updated `validateLibrary.py`, which was presumably broken.
 - Check against framework pipeline
 - Contributes to https://github.com/rest-for-physics/framework/issues/45