### PR TITLE
Update `TRestDetectorSignalToRawSignalProcess` to support calibration points and shaping

### DIFF
--- a/inc/TRestDetectorSignalToRawSignalProcess.h
+++ b/inc/TRestDetectorSignalToRawSignalProcess.h
@@ -60,6 +60,14 @@ class TRestDetectorSignalToRawSignalProcess : public TRestEventProcess {
     /// This parameter is used by integralWindow trigger mode to define the acquisition window.
     Double_t fIntegralThreshold = 1229.0;
 
+    /// two distinct energy values used for calibration
+    TVector2 fCalibrationEnergy = TVector2(0.0, 0.0);
+    /// position in the range corresponding to the energy in 'fCalibrationEnergy'. Values between 0 and 1
+    TVector2 fCalibrationRange = TVector2(0.0, 0.0);
+    /// Usage: fCalibrationEnergy = (0, 100 MeV) and fCalibrationRange = (0.1, 0.9)
+    /// will perform a linear calibration with 0 equal to 0.1 of the range (0.1 * (max - min) + min) and 100
+    /// MeV equal to 0.9 of the range. The range is the one corresponding to a Short_t for rawsignal.
+
    public:
     inline Double_t GetSampling() const { return fSampling; }
     inline void SetSampling(Double_t sampling) { fSampling = sampling; }
@@ -79,6 +87,19 @@ class TRestDetectorSignalToRawSignalProcess : public TRestEventProcess {
     inline Double_t GetIntegralThreshold() const { return fIntegralThreshold; }
     inline void SetIntegralThreshold(Double_t integralThreshold) { fIntegralThreshold = integralThreshold; }
 
+    inline bool IsLinearCalibration() const {
+        if (fCalibrationEnergy.Mod() != 0 && fCalibrationRange.Mod() != 0) {
+            return true;
+        }
+        return false;  // use the gain factor
+    }
+
+    inline TVector2 GetCalibrationEnergy() const { return fCalibrationEnergy; }
+    inline void SetCalibrationEnergy(TVector2 calibrationEnergy) { fCalibrationEnergy = calibrationEnergy; }
+
+    inline TVector2 GetCalibrationRange() const { return fCalibrationRange; }
+    inline void SetCalibrationRange(TVector2 calibrationRange) { fCalibrationRange = calibrationRange; }
+
     any GetInputEvent() const override { return fInputSignalEvent; }
     any GetOutputEvent() const override { return fOutputRawSignalEvent; }
 
@@ -94,7 +115,15 @@ class TRestDetectorSignalToRawSignalProcess : public TRestEventProcess {
         RESTMetadata << "Points per channel : " << fNPoints << RESTendl;
         RESTMetadata << "Trigger mode : " << fTriggerMode << RESTendl;
         RESTMetadata << "Trigger delay : " << fTriggerDelay << " time units" << RESTendl;
-        RESTMetadata << "ADC gain : " << fGain << RESTendl;
+
+        if (!IsLinearCalibration()) {
+            RESTMetadata << "ADC gain : " << fGain << RESTendl;
+        } else {
+            RESTMetadata << "Calibration energy : (" << fCalibrationEnergy.X() << ", "
+                         << fCalibrationEnergy.Y() << ") keV" << RESTendl;
+            RESTMetadata << "Calibration range : (" << fCalibrationRange.X() << ", " << fCalibrationRange.Y()
+                         << ")" << RESTendl;
+        }
 
         EndPrintProcess();
     }

--- a/inc/TRestDetectorSignalToRawSignalProcess.h
+++ b/inc/TRestDetectorSignalToRawSignalProcess.h
@@ -24,9 +24,8 @@
 #define RestCore_TRestDetectorSignalToRawSignalProcess
 
 #include <TRestDetectorSignalEvent.h>
+#include <TRestEventProcess.h>
 #include <TRestRawSignalEvent.h>
-
-#include "TRestEventProcess.h"
 
 //! A process to convert a TRestDetectorSignalEvent into a TRestRawSignalEvent
 class TRestDetectorSignalToRawSignalProcess : public TRestEventProcess {
@@ -165,6 +164,6 @@ class TRestDetectorSignalToRawSignalProcess : public TRestEventProcess {
     // Destructor
     ~TRestDetectorSignalToRawSignalProcess();
 
-    ClassDefOverride(TRestDetectorSignalToRawSignalProcess, 2);
+    ClassDefOverride(TRestDetectorSignalToRawSignalProcess, 3);
 };
 #endif

--- a/inc/TRestDetectorSignalToRawSignalProcess.h
+++ b/inc/TRestDetectorSignalToRawSignalProcess.h
@@ -52,7 +52,7 @@ class TRestDetectorSignalToRawSignalProcess : public TRestEventProcess {
     TString fTriggerMode = "firstDeposit";
 
     /// The number of time bins the time start is delayed in the resulting output signal.
-    Int_t fTriggerDelay = 100;  // ns
+    Int_t fTriggerDelay = 100;
 
     /// A factor the data values will be multiplied by at the output signal.
     Double_t fGain = 100.0;
@@ -67,6 +67,9 @@ class TRestDetectorSignalToRawSignalProcess : public TRestEventProcess {
     /// Usage: fCalibrationEnergy = (0, 100 MeV) and fCalibrationRange = (0.1, 0.9)
     /// will perform a linear calibration with 0 equal to 0.1 of the range (0.1 * (max - min) + min) and 100
     /// MeV equal to 0.9 of the range. The range is the one corresponding to a Short_t for rawsignal.
+
+    Double_t fTimeStart;  //!
+    Double_t fTimeEnd;    //!
 
    public:
     inline Double_t GetSampling() const { return fSampling; }
@@ -102,6 +105,8 @@ class TRestDetectorSignalToRawSignalProcess : public TRestEventProcess {
 
     any GetInputEvent() const override { return fInputSignalEvent; }
     any GetOutputEvent() const override { return fOutputRawSignalEvent; }
+
+    void InitProcess() override;
 
     TRestEvent* ProcessEvent(TRestEvent* inputEvent) override;
 

--- a/inc/TRestDetectorSignalToRawSignalProcess.h
+++ b/inc/TRestDetectorSignalToRawSignalProcess.h
@@ -57,8 +57,10 @@ class TRestDetectorSignalToRawSignalProcess : public TRestEventProcess {
     /// The starting time for the "fixed" trigger mode (can be offset by the trigger delay)
     Int_t fTriggerFixedStartTime = 0;
 
-    /// A factor the data values will be multiplied by at the output signal.
-    Double_t fGain = 100.0;
+    /// fCalibrationGain and fCalibrationOffset define the linear calibration.
+    /// output = input * fCalibrationGain + calibrationOffset
+    Double_t fCalibrationGain = 100.0;
+    Double_t fCalibrationOffset = 0.0;  // adc units
 
     /// This parameter is used by integralWindow trigger mode to define the acquisition window.
     Double_t fIntegralThreshold = 1229.0;
@@ -87,8 +89,11 @@ class TRestDetectorSignalToRawSignalProcess : public TRestEventProcess {
     inline Int_t GetTriggerDelay() const { return fTriggerDelay; }
     inline void SetTriggerDelay(Int_t triggerDelay) { fTriggerDelay = triggerDelay; }
 
-    inline Double_t GetGain() const { return fGain; }
-    inline void SetGain(Double_t gain) { fGain = gain; }
+    inline Double_t GetGain() const { return fCalibrationGain; }
+    inline void SetGain(Double_t gain) { fCalibrationGain = gain; }
+
+    inline Double_t GetCalibrationOffset() const { return fCalibrationOffset; }
+    inline void SetCalibrationOffset(Double_t offset) { fCalibrationOffset = offset; }
 
     inline Double_t GetIntegralThreshold() const { return fIntegralThreshold; }
     inline void SetIntegralThreshold(Double_t integralThreshold) { fIntegralThreshold = integralThreshold; }
@@ -124,14 +129,14 @@ class TRestDetectorSignalToRawSignalProcess : public TRestEventProcess {
         RESTMetadata << "Trigger mode : " << fTriggerMode << RESTendl;
         RESTMetadata << "Trigger delay : " << fTriggerDelay << " time units" << RESTendl;
 
-        if (!IsLinearCalibration()) {
-            RESTMetadata << "ADC gain : " << fGain << RESTendl;
-        } else {
+        if (IsLinearCalibration()) {
             RESTMetadata << "Calibration energy : (" << fCalibrationEnergy.X() << ", "
                          << fCalibrationEnergy.Y() << ") keV" << RESTendl;
             RESTMetadata << "Calibration range : (" << fCalibrationRange.X() << ", " << fCalibrationRange.Y()
                          << ")" << RESTendl;
         }
+        RESTMetadata << "ADC Gain : " << fCalibrationGain << RESTendl;
+        RESTMetadata << "ADC Offset : " << fCalibrationOffset << RESTendl;
 
         EndPrintProcess();
     }

--- a/inc/TRestDetectorSignalToRawSignalProcess.h
+++ b/inc/TRestDetectorSignalToRawSignalProcess.h
@@ -73,6 +73,10 @@ class TRestDetectorSignalToRawSignalProcess : public TRestEventProcess {
     /// will perform a linear calibration with 0 equal to 0.1 of the range (0.1 * (max - min) + min) and 100
     /// MeV equal to 0.9 of the range. The range is the one corresponding to a Short_t for rawsignal.
 
+    /// If defined ( > 0 ) we will compute the sin shaping of the signal, this is done in this process to
+    /// avoid artifacts in the signal (e.g. signals not getting cut when they should)
+    Double_t fShapingTime = 0.0;  // us
+
     Double_t fTimeStart;  //!
     Double_t fTimeEnd;    //!
 
@@ -98,11 +102,14 @@ class TRestDetectorSignalToRawSignalProcess : public TRestEventProcess {
     inline Double_t GetIntegralThreshold() const { return fIntegralThreshold; }
     inline void SetIntegralThreshold(Double_t integralThreshold) { fIntegralThreshold = integralThreshold; }
 
+    inline Double_t GetShapingTime() const { return fShapingTime; }
+    inline void SetShapingTime(Double_t shapingTime) { fShapingTime = shapingTime; }
+
+    inline bool IsShapingEnabled() const { return fShapingTime > 0; }
+
     inline bool IsLinearCalibration() const {
-        if (fCalibrationEnergy.Mod() != 0 && fCalibrationRange.Mod() != 0) {
-            return true;
-        }
-        return false;  // use the gain factor
+        // Will return true if two points have been given for calibration
+        return (fCalibrationEnergy.Mod() != 0 && fCalibrationRange.Mod() != 0);
     }
 
     inline TVector2 GetCalibrationEnergy() const { return fCalibrationEnergy; }
@@ -137,6 +144,10 @@ class TRestDetectorSignalToRawSignalProcess : public TRestEventProcess {
         }
         RESTMetadata << "ADC Gain : " << fCalibrationGain << RESTendl;
         RESTMetadata << "ADC Offset : " << fCalibrationOffset << RESTendl;
+
+        if (IsShapingEnabled()) {
+            RESTMetadata << "Shaping time : " << fShapingTime << " us" << RESTendl;
+        }
 
         EndPrintProcess();
     }

--- a/inc/TRestDetectorSignalToRawSignalProcess.h
+++ b/inc/TRestDetectorSignalToRawSignalProcess.h
@@ -54,6 +54,9 @@ class TRestDetectorSignalToRawSignalProcess : public TRestEventProcess {
     /// The number of time bins the time start is delayed in the resulting output signal.
     Int_t fTriggerDelay = 100;
 
+    /// The starting time for the "fixed" trigger mode (can be offset by the trigger delay)
+    Int_t fTriggerFixedStartTime = 0;
+
     /// A factor the data values will be multiplied by at the output signal.
     Double_t fGain = 100.0;
 

--- a/src/TRestDetectorSignalToRawSignalProcess.cxx
+++ b/src/TRestDetectorSignalToRawSignalProcess.cxx
@@ -301,8 +301,13 @@ TRestEvent* TRestDetectorSignalToRawSignalProcess::ProcessEvent(TRestEvent* inpu
 /// TRestDetectorSignalToRawSignalProcess metadata section
 ///
 void TRestDetectorSignalToRawSignalProcess::InitFromConfigFile() {
+    auto nPoints = GetParameter("nPoints");
+    if (nPoints == PARAMETER_NOT_FOUND_STR) {
+        nPoints = GetParameter("Npoints", fNPoints);
+    }
+    fNPoints = StringToInteger(nPoints);
+
     fSampling = GetDblParameterWithUnits("sampling");
-    fNPoints = StringToInteger(GetParameter("Npoints", "512"));
     fTriggerMode = GetParameter("triggerMode", "firstDeposit");
     fTriggerDelay = StringToInteger(GetParameter("triggerDelay", 100));
     fIntegralThreshold = StringToDouble(GetParameter("integralThreshold", "1229"));

--- a/src/TRestDetectorSignalToRawSignalProcess.cxx
+++ b/src/TRestDetectorSignalToRawSignalProcess.cxx
@@ -247,7 +247,7 @@ TRestEvent* TRestDetectorSignalToRawSignalProcess::ProcessEvent(TRestEvent* inpu
 
                 RESTDebug << "Adding data : " << signal->GetData(m) << " to Time Bin : " << timeBin
                           << RESTendl;
-                data[timeBin] += fGain * signal->GetData(m);
+                data[timeBin] += fCalibrationGain * signal->GetData(m) + fCalibrationOffset;
             }
         }
 
@@ -316,9 +316,16 @@ void TRestDetectorSignalToRawSignalProcess::InitFromConfigFile() {
     fIntegralThreshold = StringToDouble(GetParameter("integralThreshold", fIntegralThreshold));
     fTriggerFixedStartTime = StringToInteger(GetParameter("triggerFixedStartTime", fTriggerFixedStartTime));
 
-    fGain = StringToDouble(GetParameter("gain", fGain));
+    fCalibrationGain = StringToDouble(GetParameter("gain", fCalibrationGain));
+    fCalibrationOffset = StringToDouble(GetParameter("offset", fCalibrationOffset));
     fCalibrationEnergy = Get2DVectorParameterWithUnits("calibrationEnergy", fCalibrationEnergy);
     fCalibrationRange = Get2DVectorParameterWithUnits("calibrationRange", fCalibrationRange);
+
+    if (IsLinearCalibration()) {
+        fCalibrationGain = (fCalibrationRange.Y() - fCalibrationRange.X()) /
+                           (fCalibrationEnergy.Y() - fCalibrationEnergy.X());
+        fCalibrationOffset = fCalibrationRange.X() - fCalibrationGain * fCalibrationEnergy.X();
+    }
 }
 
 void TRestDetectorSignalToRawSignalProcess::InitProcess() {

--- a/src/TRestDetectorSignalToRawSignalProcess.cxx
+++ b/src/TRestDetectorSignalToRawSignalProcess.cxx
@@ -238,11 +238,12 @@ TRestEvent* TRestDetectorSignalToRawSignalProcess::ProcessEvent(TRestEvent* inpu
                 // convert physical time (in us) to timeBin
                 Int_t timeBin = (Int_t)round((t - fTimeStart) / fSampling);
 
-                if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Warning)
+                if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Warning) {
                     if (timeBin < 0 || timeBin > fNPoints) {
                         cout << "Time bin out of range!!! bin value : " << timeBin << endl;
                         timeBin = 0;
                     }
+                }
 
                 RESTDebug << "Adding data : " << signal->GetData(m) << " to Time Bin : " << timeBin
                           << RESTendl;

--- a/src/TRestDetectorSignalToRawSignalProcess.cxx
+++ b/src/TRestDetectorSignalToRawSignalProcess.cxx
@@ -183,7 +183,9 @@ TRestEvent* TRestDetectorSignalToRawSignalProcess::ProcessEvent(TRestEvent* inpu
 
     if (fInputSignalEvent->GetNumberOfSignals() <= 0) return nullptr;
 
-    if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Debug) fOutputRawSignalEvent->PrintEvent();
+    if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Debug) {
+        fOutputRawSignalEvent->PrintEvent();
+    }
 
     fOutputRawSignalEvent->SetID(fInputSignalEvent->GetID());
     fOutputRawSignalEvent->SetSubID(fInputSignalEvent->GetSubID());
@@ -289,7 +291,7 @@ TRestEvent* TRestDetectorSignalToRawSignalProcess::ProcessEvent(TRestEvent* inpu
     }
 
     RESTDebug << "TRestDetectorSignalToRawSignalProcess. Returning event with N signals "
-          << fOutputRawSignalEvent->GetNumberOfSignals() << RESTendl;
+              << fOutputRawSignalEvent->GetNumberOfSignals() << RESTendl;
 
     return fOutputRawSignalEvent;
 }
@@ -303,6 +305,9 @@ void TRestDetectorSignalToRawSignalProcess::InitFromConfigFile() {
     fNPoints = StringToInteger(GetParameter("Npoints", "512"));
     fTriggerMode = GetParameter("triggerMode", "firstDeposit");
     fTriggerDelay = StringToInteger(GetParameter("triggerDelay", 100));
-    fGain = StringToDouble(GetParameter("gain", "100"));
     fIntegralThreshold = StringToDouble(GetParameter("integralThreshold", "1229"));
+
+    fGain = StringToDouble(GetParameter("gain", "100"));
+    fCalibrationEnergy = Get2DVectorParameterWithUnits("calibrationEnergy", fCalibrationEnergy);
+    fCalibrationRange = Get2DVectorParameterWithUnits("calibrationRange", fCalibrationRange);
 }


### PR DESCRIPTION
![lobis](https://badgen.net/badge/PR%20submitted%20by%3A/lobis/blue) ![Medium: 195](https://badgen.net/badge/PR%20Size/Medium%3A%20195/orange) [![](https://gitlab.cern.ch/rest-for-physics/framework/badges/lobis-detector-to-raw-calibration/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/framework/-/commits/lobis-detector-to-raw-calibration)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

This PR updates `TRestDetectorSignalToRawSignalProcess` with the following:

* A new trigger mode `"fixed"` has been implemented, where the user can manually set the exact time of the first bien (instead of using the time of the first deposit).
For example, a configuration such as
```
<parameter name="sampling" value="1us"/>
<parameter name="nPoints" value="512"/>
<parameter name="triggerMode" value="fixed"/>
<parameter name="triggerFixedStartTime" value="55.0us"/>
<parameter name="triggerDelay" value="100"/>
```

would have a starting time of 55.0 us - 1.0 * 100 us as it is affected by the `triggerDelay` parameter.

* A new parameter `offset` (`fCalibrationOffset`) has been introduced to allow for more calibration options besides the gain. This allows to set our zero elsewhere than on the middle of the range.
* A new way of calibration has been introduced which can be used as an alternative to the gain/offset. Instead of fixing the gain and offset (optional), we can specify two points to establish a linear relation between energy and ADC. For example:
```
<parameter name="calibrationEnergy" value="(0,10)MeV"/>
<parameter name="calibrationRange" value="(0.1,0.9)"/>
```
would generate a gain and offset such that 0 energy corresponds to 0.1 or 10% of our range (-32768 + 0.1 * 65535 in ADC units) and 10 Mev to 90% of our range. I believe this way is more intuitive and allows an easier reproduction of experimental calibration.

* Shaping has been implemented in `TRestDetectorSignalToRawSignalProcess`. Even though shaping is implemented already in rawlib (`TRestRawSignalShapingProcess`) it presents a few problems, mainly information loss when dealing with signals above the saturation limit.

The image below corresponds to the output of `TRestDetectorSignalToRawSignalProcess` after these changes. Note how some of the peaks are cut off due to saturation (as would happen on a physical experiment).

![image](https://user-images.githubusercontent.com/35803280/187754004-099f55b2-3840-4b97-b71e-7a04c409b46b.png)

If we were to convert the detector signal into raw signal without the shaping, we would get something such as the image below.

![image](https://user-images.githubusercontent.com/35803280/187758245-897c5347-52fc-4442-b09d-720b945a01da.png)

If we were to perform shaping to this event, it would be impossible to get the first result, which is more physical, since the information of how much each signal is above the saturation limit is lost. We would get peaks with the maximum exactly equal to the saturation limit, which does not correspond to the physical event since signals with different energy would be exactly equal (such as the first peaks of green and yellow in the images).