### PR TITLE
Replacing custom branch pipeline by master

### DIFF
--- a/.github/workflows/frameworkValidation.yml
+++ b/.github/workflows/frameworkValidation.yml
@@ -20,4 +20,4 @@ defaults:
 
 jobs:
   framework-validation:
-    uses: rest-for-physics/framework/.github/workflows/validation.yml@submodule-validation
+    uses: rest-for-physics/framework/.github/workflows/validation.yml@master

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -21,7 +21,7 @@ jobs:
     container:
       image: ghcr.io/lobis/root-geant4-garfield:rest-for-physics
     steps:
-      - uses: rest-for-physics/framework/.github/actions/checkout@submodule-validation
+      - uses: rest-for-physics/framework/.github/actions/checkout@master
         with:
           branch: ${{ env.BRANCH_NAME }}
           repository: rest-for-physics/connectorslib
@@ -35,7 +35,7 @@ jobs:
       image: ghcr.io/lobis/root-geant4-garfield:rest-for-physics
     steps:
       - name: Checkout connectorslib
-        uses: rest-for-physics/framework/.github/actions/checkout@submodule-validation
+        uses: rest-for-physics/framework/.github/actions/checkout@master
         with:
           branch: ${{ env.BRANCH_NAME }}
           repository: rest-for-physics/connectorslib


### PR DESCRIPTION
![juanangp](https://badgen.net/badge/PR%20submitted%20by%3A/juanangp/blue) ![Ok: 3](https://badgen.net/badge/PR%20Size/Ok%3A%203/green) [![](https://gitlab.cern.ch/rest-for-physics/framework/badges/pipeline-fix/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/framework/-/commits/pipeline-fix)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Custom branch was added to the different submodules pipelines at https://github.com/rest-for-physics/framework/pull/371, adding master branch to avoid potential pipeline issues

Related PR
https://github.com/rest-for-physics/framework/pull/377