### PR TITLE
Adding the possibility to perform smoothing on TRestRawToDetectorSignalProcess

### DIFF
--- a/inc/TRestRawToDetectorSignalProcess.h
+++ b/inc/TRestRawToDetectorSignalProcess.h
@@ -73,13 +73,20 @@ class TRestRawToDetectorSignalProcess : public TRestEventProcess {
     /// A parameter to determine if baseline correction has been applied by a previous process
     Bool_t fBaseLineCorrection = false;
 
+    // Perform signal smoothing to the data
+    Bool_t fSignalSmoothing = false;
+
+    // In case signal smoothing is active provide averaging points
+    Int_t fAveragingPoints = 5;
+
    public:
     any GetInputEvent() const override { return fInputSignalEvent; }
     any GetOutputEvent() const override { return fOutputSignalEvent; }
 
     TRestEvent* ProcessEvent(TRestEvent* inputEvent) override;
 
-    void ZeroSuppresion(TRestRawSignal* rawSignal, TRestDetectorSignal& sgnl);
+    void ProcessSignal(TRestRawSignal* rawSignal, TRestDetectorSignal& sgnl);
+    void ProcessSignalSmoothed(TRestRawSignal* rawSignal, TRestDetectorSignal& sgnl);
 
     /// It prints out the process parameters stored in the metadata structure
     void PrintMetadata() override {
@@ -90,6 +97,7 @@ class TRestRawToDetectorSignalProcess : public TRestEventProcess {
         RESTMetadata << "Gain : " << fGain << RESTendl;
 
         if (fZeroSuppression) {
+            RESTMetadata << "ZeroSuppression is enabled " << RESTendl;
             RESTMetadata << "Base line range definition : ( " << fBaseLineRange.X() << " , "
                          << fBaseLineRange.Y() << " ) " << RESTendl;
             RESTMetadata << "Integral range : ( " << fIntegralRange.X() << " , " << fIntegralRange.Y()
@@ -99,8 +107,11 @@ class TRestRawToDetectorSignalProcess : public TRestEventProcess {
             RESTMetadata << "Number of points over threshold : " << fNPointsOverThreshold << RESTendl;
         }
 
-        if (fBaseLineCorrection)
-            RESTMetadata << "BaseLine correction is enabled for TRestRawSignalAnalysisProcess" << RESTendl;
+        if (fBaseLineCorrection) RESTMetadata << "BaseLine correction is enabled" << RESTendl;
+        if (fSignalSmoothing) {
+            RESTMetadata << "Signal smoothing is enabled" << RESTendl;
+            RESTMetadata << "Averaging points " << fAveragingPoints << RESTendl;
+        }
 
         EndPrintProcess();
     }
@@ -117,6 +128,6 @@ class TRestRawToDetectorSignalProcess : public TRestEventProcess {
     // Destructor
     ~TRestRawToDetectorSignalProcess();
 
-    ClassDefOverride(TRestRawToDetectorSignalProcess, 2);
+    ClassDefOverride(TRestRawToDetectorSignalProcess, 3);
 };
 #endif

--- a/src/TRestRawToDetectorSignalProcess.cxx
+++ b/src/TRestRawToDetectorSignalProcess.cxx
@@ -205,8 +205,8 @@ void TRestRawToDetectorSignalProcess::ProcessSignalSmoothed(TRestRawSignal* rawS
         auto pOver = TRestSignalAnalysis::GetPointsOverThreshold(
             smoothed, fIntegralRange, TVector2(fPointThreshold, fSignalThreshold), fNPointsOverThreshold, 512,
             baseline, baselineSigma);
-        for (const auto& j : pOver) {
-            sgnl.NewPoint(fTriggerStarts + fSampling * j, fGain * smoothed[j] - baseline);
+        for (const auto& [j, data] : pOver) {
+            sgnl.NewPoint(fTriggerStarts + fSampling * j, fGain * data);
         }
     } else {
         for (size_t p = 0; p < smoothed.size(); p++) {
@@ -227,8 +227,8 @@ void TRestRawToDetectorSignalProcess::ProcessSignal(TRestRawSignal* rawSignal, T
                                                  fNPointsOverThreshold, 512);
 
         auto pOver = rawSignal->GetPointsOverThreshold();
-        for (const auto& j : pOver) {
-            sgnl.NewPoint(fTriggerStarts + fSampling * j, fGain * rawSignal->GetData(j));
+        for (const auto& [j, data] : pOver) {
+            sgnl.NewPoint(fTriggerStarts + fSampling * j, fGain * data);
         }
     } else {
         for (int p = 0; p < rawSignal->GetNumberOfPoints(); p++)

--- a/src/TRestRawToDetectorSignalProcess.cxx
+++ b/src/TRestRawToDetectorSignalProcess.cxx
@@ -117,6 +117,8 @@
 ///             Javier Galan
 /// 2022-January: Adding ZeroSuppression method
 ///             JuanAn Garcia
+/// 2023-April: Added new method to process smoothed data
+///             JuanAn Garcia
 ///
 /// \class      TRestRawToDetectorSignalProcess
 /// \author     Javier Gracia

--- a/src/TRestRawToDetectorSignalProcess.cxx
+++ b/src/TRestRawToDetectorSignalProcess.cxx
@@ -129,7 +129,7 @@
 ///
 #include "TRestRawToDetectorSignalProcess.h"
 
-#include "TRestSignalAnalysis.h"
+#include "TRestPulseShapeAnalysis.h"
 using namespace std;
 
 ClassImp(TRestRawToDetectorSignalProcess);
@@ -201,12 +201,12 @@ TRestEvent* TRestRawToDetectorSignalProcess::ProcessEvent(TRestEvent* inputEvent
 ///
 void TRestRawToDetectorSignalProcess::ProcessSignalSmoothed(TRestRawSignal* rawSignal,
                                                             TRestDetectorSignal& sgnl) {
-    auto smoothed = TRestSignalAnalysis::GetSignalSmoothed(rawSignal->GetData(), fAveragingPoints);
+    auto smoothed = TRestPulseShapeAnalysis::GetSignalSmoothed(rawSignal->GetData(), fAveragingPoints);
     const double baselineSigma = rawSignal->GetBaseLineSigma();
     if (fZeroSuppression) {
-        auto pOver = TRestSignalAnalysis::GetPointsOverThreshold(smoothed, fIntegralRange,
-                                                                 TVector2(fPointThreshold, fSignalThreshold),
-                                                                 fNPointsOverThreshold, 512, baselineSigma);
+        auto pOver = TRestPulseShapeAnalysis::GetPointsOverThreshold(
+            smoothed, fIntegralRange, TVector2(fPointThreshold, fSignalThreshold), fNPointsOverThreshold, 512,
+            baselineSigma);
         for (const auto& [j, data] : pOver) {
             sgnl.NewPoint(fTriggerStarts + fSampling * j, fGain * data);
         }

--- a/src/TRestRawToDetectorSignalProcess.cxx
+++ b/src/TRestRawToDetectorSignalProcess.cxx
@@ -199,19 +199,18 @@ TRestEvent* TRestRawToDetectorSignalProcess::ProcessEvent(TRestEvent* inputEvent
 ///
 void TRestRawToDetectorSignalProcess::ProcessSignalSmoothed(TRestRawSignal* rawSignal,
                                                             TRestDetectorSignal& sgnl) {
-    auto smoothed = rawSignal->GetSignalSmoothed(fAveragingPoints);
-    const double baseline = rawSignal->GetBaseLine();
+    auto smoothed = TRestSignalAnalysis::GetSignalSmoothed(rawSignal->GetData(), fAveragingPoints);
     const double baselineSigma = rawSignal->GetBaseLineSigma();
     if (fZeroSuppression) {
-        auto pOver = TRestSignalAnalysis::GetPointsOverThreshold(
-            smoothed, fIntegralRange, TVector2(fPointThreshold, fSignalThreshold), fNPointsOverThreshold, 512,
-            baseline, baselineSigma);
+        auto pOver = TRestSignalAnalysis::GetPointsOverThreshold(smoothed, fIntegralRange,
+                                                                 TVector2(fPointThreshold, fSignalThreshold),
+                                                                 fNPointsOverThreshold, 512, baselineSigma);
         for (const auto& [j, data] : pOver) {
             sgnl.NewPoint(fTriggerStarts + fSampling * j, fGain * data);
         }
     } else {
         for (size_t p = 0; p < smoothed.size(); p++) {
-            const double data = smoothed[p] - baseline;
+            const double data = smoothed[p];
             if (data > fThreshold) sgnl.NewPoint(fTriggerStarts + fSampling * p, fGain * data);
         }
     }

--- a/src/TRestRawToDetectorSignalProcess.cxx
+++ b/src/TRestRawToDetectorSignalProcess.cxx
@@ -126,6 +126,7 @@
 /// <hr>
 ///
 #include "TRestRawToDetectorSignalProcess.h"
+
 #include "TRestSignalAnalysis.h"
 using namespace std;
 

--- a/src/TRestRawToDetectorSignalProcess.cxx
+++ b/src/TRestRawToDetectorSignalProcess.cxx
@@ -209,7 +209,7 @@ void TRestRawToDetectorSignalProcess::ProcessSignalSmoothed(TRestRawSignal* rawS
             sgnl.NewPoint(fTriggerStarts + fSampling * j, fGain * smoothed[j] - baseline);
         }
     } else {
-        for (int p = 0; p < smoothed.size(); p++) {
+        for (size_t p = 0; p < smoothed.size(); p++) {
             const double data = smoothed[p] - baseline;
             if (data > fThreshold) sgnl.NewPoint(fTriggerStarts + fSampling * p, fGain * data);
         }


### PR DESCRIPTION
![juanangp](https://badgen.net/badge/PR%20submitted%20by%3A/juanangp/blue) ![Ok: 74](https://badgen.net/badge/PR%20Size/Ok%3A%2074/green) [![](https://gitlab.cern.ch/rest-for-physics/framework/badges/signal-ana/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/framework/-/commits/signal-ana) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=rest-for-physics&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Implementing the possibility to perform smoothing inside  `TRestRawToDetectorSignalProcess` by using generic analysis methods from https://github.com/rest-for-physics/framework/pull/379