### PR TITLE
avoid duplicates in volume ids

### DIFF
--- a/src/TRestGeant4ToDetectorHitsProcess.cxx
+++ b/src/TRestGeant4ToDetectorHitsProcess.cxx
@@ -138,18 +138,21 @@ void TRestGeant4ToDetectorHitsProcess::InitProcess() {
     fG4Metadata = GetMetadata<TRestGeant4Metadata>();
 
     for (unsigned int n = 0; n < fVolumeSelection.size(); n++) {
-        if (fG4Metadata->GetActiveVolumeID(fVolumeSelection[n]) >= 0)
+        if (fG4Metadata->GetActiveVolumeID(fVolumeSelection[n]) >= 0) {
             fVolumeId.push_back(fG4Metadata->GetActiveVolumeID(fVolumeSelection[n]));
-        else if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Warning)
+        } else if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Warning)
             cout << "TRestGeant4ToDetectorHitsProcess. volume name : " << fVolumeSelection[n]
                  << " not found and will not be added." << endl;
     }
 
-    /* {{{ Debug output */
+    sort(fVolumeId.begin(), fVolumeId.end());
+    fVolumeId.erase(unique(fVolumeId.begin(), fVolumeId.end()), fVolumeId.end());
+
     RESTDebug << "Active volumes available in TRestGeant4Metadata" << RESTendl;
     RESTDebug << "-------------------------------------------" << RESTendl;
-    for (unsigned int n = 0; n < fG4Metadata->GetNumberOfActiveVolumes(); n++)
+    for (unsigned int n = 0; n < fG4Metadata->GetNumberOfActiveVolumes(); n++) {
         RESTDebug << "Volume id : " << n << " name : " << fG4Metadata->GetActiveVolumeName(n) << RESTendl;
+    }
     RESTDebug << RESTendl;
 
     RESTDebug << "TRestGeant4HitsProcess volumes enabled in RML : ";
@@ -180,7 +183,6 @@ void TRestGeant4ToDetectorHitsProcess::InitProcess() {
             }
         RESTDebug << " " << RESTendl;
     }
-    /* }}} */
 }
 
 ///////////////////////////////////////////////
@@ -246,8 +248,9 @@ void TRestGeant4ToDetectorHitsProcess::InitFromConfigFile() {
 void TRestGeant4ToDetectorHitsProcess::PrintMetadata() {
     BeginPrintProcess();
 
-    for (unsigned int n = 0; n < fVolumeSelection.size(); n++)
+    for (unsigned int n = 0; n < fVolumeSelection.size(); n++) {
         RESTMetadata << "Volume added : " << fVolumeSelection[n] << RESTendl;
+    }
 
     EndPrintProcess();
 }


### PR DESCRIPTION
![lobis](https://badgen.net/badge/PR%20submitted%20by%3A/lobis/blue) ![Ok: 9](https://badgen.net/badge/PR%20Size/Ok%3A%209/green) [![](https://gitlab.cern.ch/rest-for-physics/framework/badges/lobis-fix-geant4-to-detector/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/framework/-/commits/lobis-fix-geant4-to-detector)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

When trying to compute the energy with a configuration such as:

```
<addProcess type="TRestGeant4ToDetectorHitsProcess" name="G4ToHits" value="ON">
    <addVolume name="Chamber_gas"/>
</addProcess>
```

I noticed the energy of the hits is double as excepted, because it's adding the volume id of the volume twice for some reason. This PR removes duplicates from the volume id container.