### PR TITLE
TRestDetectorSignalToRawSignalProcess. InitFromConfigFile removed

### DIFF
--- a/inc/TRestDetectorSignalToRawSignalProcess.h
+++ b/inc/TRestDetectorSignalToRawSignalProcess.h
@@ -36,8 +36,6 @@ class TRestDetectorSignalToRawSignalProcess : public TRestEventProcess {
     /// A pointer to the specific TRestRawSignalEvent input
     TRestRawSignalEvent* fOutputRawSignalEvent;  //!
 
-    void InitFromConfigFile() override;
-
     void Initialize() override;
 
    protected:


### PR DESCRIPTION
![jgalan](https://badgen.net/badge/PR%20submitted%20by%3A/jgalan/blue) ![Ok: 29](https://badgen.net/badge/PR%20Size/Ok%3A%2029/green) [![](https://gitlab.cern.ch/rest-for-physics/framework/badges/jgalan_signalToRaw_update/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/framework/-/commits/jgalan_signalToRaw_update)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

I just remove `InitFromConfigFile` since it should no be necessary in this process.