### PR TITLE
TRestGeant4ToDetectorHitsProcess: Support adding volumes by physical/logical and expressions and do not store repeated volumes

### DIFF
--- a/inc/TRestGeant4ToDetectorHitsProcess.h
+++ b/inc/TRestGeant4ToDetectorHitsProcess.h
@@ -31,15 +31,15 @@
 
 /// A process to transform a *TRestGeant4Event* into a *TRestDetectorHitsEvent*.
 class TRestGeant4ToDetectorHitsProcess : public TRestEventProcess {
-private:
+   private:
     /// A pointer to the input TRestGeant4Event
-    TRestGeant4Event *fGeant4Event;  //!
+    TRestGeant4Event* fGeant4Event;  //!
 
     /// A pointer to the Geant4 simulation conditions stored in TRestGeant4Metadata
-    TRestGeant4Metadata *fGeant4Metadata;  //!
+    TRestGeant4Metadata* fGeant4Metadata;  //!
 
     /// A pointer to the output TRestDetectorHitsEvent
-    TRestDetectorHitsEvent *fHitsEvent;  //!
+    TRestDetectorHitsEvent* fHitsEvent;  //!
 
     /// The volume ids from the volumes selected for transfer to TRestDetectorHitsEvent
     std::vector<Int_t> fVolumeId;  //!
@@ -53,35 +53,35 @@ private:
 
     void LoadDefaultConfig();
 
-protected:
+   protected:
     // add here the members of your event process
 
-public:
+   public:
     any GetInputEvent() const override { return fGeant4Event; }
 
     any GetOutputEvent() const override { return fHitsEvent; }
 
     void InitProcess() override;
 
-    TRestEvent *ProcessEvent(TRestEvent *inputEvent) override;
+    TRestEvent* ProcessEvent(TRestEvent* inputEvent) override;
 
-    void LoadConfig(const std::string &configFilename, const std::string &name = "");
+    void LoadConfig(const std::string& configFilename, const std::string& name = "");
 
     void PrintMetadata() override;
 
     /// Returns the name of this process
-    const char *GetProcessName() const override { return "geant4toHits"; }
+    const char* GetProcessName() const override { return "geant4toHits"; }
 
     // Constructor
     TRestGeant4ToDetectorHitsProcess();
 
-    explicit TRestGeant4ToDetectorHitsProcess(const char *configFilename);
+    explicit TRestGeant4ToDetectorHitsProcess(const char* configFilename);
 
     // Destructor
     ~TRestGeant4ToDetectorHitsProcess() override;
 
-ClassDefOverride(TRestGeant4ToDetectorHitsProcess, 1);  // Transform a TRestGeant4Event event to a
-    // TRestDetectorHitsEvent (hits-collection event)
+    ClassDefOverride(TRestGeant4ToDetectorHitsProcess, 1);  // Transform a TRestGeant4Event event to a
+                                                            // TRestDetectorHitsEvent (hits-collection event)
 };
 
 #endif

--- a/inc/TRestGeant4ToDetectorHitsProcess.h
+++ b/inc/TRestGeant4ToDetectorHitsProcess.h
@@ -80,7 +80,7 @@ class TRestGeant4ToDetectorHitsProcess : public TRestEventProcess {
     // Destructor
     ~TRestGeant4ToDetectorHitsProcess() override;
 
-    ClassDefOverride(TRestGeant4ToDetectorHitsProcess, 1);  // Transform a TRestGeant4Event event to a
+    ClassDefOverride(TRestGeant4ToDetectorHitsProcess, 2);  // Transform a TRestGeant4Event event to a
                                                             // TRestDetectorHitsEvent (hits-collection event)
 };
 

--- a/inc/TRestGeant4ToDetectorHitsProcess.h
+++ b/inc/TRestGeant4ToDetectorHitsProcess.h
@@ -31,15 +31,15 @@
 
 /// A process to transform a *TRestGeant4Event* into a *TRestDetectorHitsEvent*.
 class TRestGeant4ToDetectorHitsProcess : public TRestEventProcess {
-   private:
+private:
     /// A pointer to the input TRestGeant4Event
-    TRestGeant4Event* fG4Event;  //!
+    TRestGeant4Event *fGeant4Event;  //!
 
     /// A pointer to the Geant4 simulation conditions stored in TRestGeant4Metadata
-    TRestGeant4Metadata* fG4Metadata;  //!
+    TRestGeant4Metadata *fGeant4Metadata;  //!
 
     /// A pointer to the output TRestDetectorHitsEvent
-    TRestDetectorHitsEvent* fHitsEvent;  //!
+    TRestDetectorHitsEvent *fHitsEvent;  //!
 
     /// The volume ids from the volumes selected for transfer to TRestDetectorHitsEvent
     std::vector<Int_t> fVolumeId;  //!
@@ -53,31 +53,35 @@ class TRestGeant4ToDetectorHitsProcess : public TRestEventProcess {
 
     void LoadDefaultConfig();
 
-   protected:
+protected:
     // add here the members of your event process
 
-   public:
-    any GetInputEvent() const override { return fG4Event; }
+public:
+    any GetInputEvent() const override { return fGeant4Event; }
+
     any GetOutputEvent() const override { return fHitsEvent; }
 
     void InitProcess() override;
 
-    TRestEvent* ProcessEvent(TRestEvent* inputEvent) override;
+    TRestEvent *ProcessEvent(TRestEvent *inputEvent) override;
 
-    void LoadConfig(const std::string& configFilename, const std::string& name = "");
+    void LoadConfig(const std::string &configFilename, const std::string &name = "");
 
     void PrintMetadata() override;
 
     /// Returns the name of this process
-    const char* GetProcessName() const override { return "g4toHitsEvent"; }
+    const char *GetProcessName() const override { return "geant4toHits"; }
 
     // Constructor
     TRestGeant4ToDetectorHitsProcess();
-    TRestGeant4ToDetectorHitsProcess(const char* configFilename);
-    // Destructor
-    ~TRestGeant4ToDetectorHitsProcess();
 
-    ClassDefOverride(TRestGeant4ToDetectorHitsProcess, 1);  // Transform a TRestGeant4Event event to a
-                                                            // TRestDetectorHitsEvent (hits-collection event)
+    explicit TRestGeant4ToDetectorHitsProcess(const char *configFilename);
+
+    // Destructor
+    ~TRestGeant4ToDetectorHitsProcess() override;
+
+ClassDefOverride(TRestGeant4ToDetectorHitsProcess, 1);  // Transform a TRestGeant4Event event to a
+    // TRestDetectorHitsEvent (hits-collection event)
 };
+
 #endif

--- a/src/TRestGeant4ToDetectorHitsProcess.cxx
+++ b/src/TRestGeant4ToDetectorHitsProcess.cxx
@@ -82,7 +82,7 @@ TRestGeant4ToDetectorHitsProcess::TRestGeant4ToDetectorHitsProcess() { Initializ
 ///
 /// \param configFilename A const char* giving the path to an RML file.
 ///
-TRestGeant4ToDetectorHitsProcess::TRestGeant4ToDetectorHitsProcess(const char *configFilename) {
+TRestGeant4ToDetectorHitsProcess::TRestGeant4ToDetectorHitsProcess(const char* configFilename) {
     Initialize();
 
     if (LoadConfigFromFile(configFilename)) LoadDefaultConfig();
@@ -126,7 +126,7 @@ void TRestGeant4ToDetectorHitsProcess::Initialize() {
 /// \param name The name of the specific metadata. It will be used to find the
 /// corresponding TRestGeant4ToDetectorHitsProcess section inside the RML.
 ///
-void TRestGeant4ToDetectorHitsProcess::LoadConfig(const string &configFilename, const string &name) {
+void TRestGeant4ToDetectorHitsProcess::LoadConfig(const string& configFilename, const string& name) {
     if (LoadConfigFromFile(configFilename, name)) LoadDefaultConfig();
 }
 
@@ -188,8 +188,8 @@ void TRestGeant4ToDetectorHitsProcess::InitProcess() {
 ///////////////////////////////////////////////
 /// \brief The main processing event function
 ///
-TRestEvent *TRestGeant4ToDetectorHitsProcess::ProcessEvent(TRestEvent *inputEvent) {
-    fG4Event = (TRestGeant4Event *) inputEvent;
+TRestEvent* TRestGeant4ToDetectorHitsProcess::ProcessEvent(TRestEvent* inputEvent) {
+    fG4Event = (TRestGeant4Event*)inputEvent;
 
     if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Extreme) {
         cout << "------ TRestGeant4ToDetectorHitsProcess --- Printing Input Event --- START ----" << endl;
@@ -207,11 +207,11 @@ TRestEvent *TRestGeant4ToDetectorHitsProcess::ProcessEvent(TRestEvent *inputEven
     fHitsEvent->SetState(fG4Event->isOk());
 
     for (unsigned int i = 0; i < fG4Event->GetNumberOfTracks(); i++) {
-        const auto &track = fG4Event->GetTrack(i);
-        const auto &hits = track.GetHits();
+        const auto& track = fG4Event->GetTrack(i);
+        const auto& hits = track.GetHits();
         for (unsigned int j = 0; j < track.GetNumberOfHits(); j++) {
             const auto energy = hits.GetEnergy(j);
-            for (const auto &volumeID: fVolumeId) {
+            for (const auto& volumeID : fVolumeId) {
                 if (hits.GetVolumeId(j) == volumeID && energy > 0) {
                     fHitsEvent->AddHit(hits.GetX(j), hits.GetY(j), hits.GetZ(j), energy);
                 }
@@ -236,40 +236,43 @@ TRestEvent *TRestGeant4ToDetectorHitsProcess::ProcessEvent(TRestEvent *inputEven
 ///
 void TRestGeant4ToDetectorHitsProcess::InitFromConfigFile() {
     // Attempt to access TRestGeant4Metadata
-    TRestGeant4Metadata *g4Metadata = GetMetadata<TRestGeant4Metadata>();
+    TRestGeant4Metadata* g4Metadata = GetMetadata<TRestGeant4Metadata>();
     if (g4Metadata == nullptr) {
-        RESTWarning << "TRestGeant4ToDetectorHitsProcess. No TRestGeant4Metadata found in the input file" << RESTendl;
+        RESTWarning << "TRestGeant4ToDetectorHitsProcess. No TRestGeant4Metadata found in the input file"
+                    << RESTendl;
     }
 
     size_t position = 0;
     string addVolumeDefinition;
 
     while ((addVolumeDefinition = GetKEYDefinition("addVolume", position)) != "") {
-        set <string> volumesToAdd;
+        set<string> volumesToAdd;
 
         const auto volumeSelection = GetFieldValue("name", addVolumeDefinition);
         if (g4Metadata != nullptr) {
-            const auto &geometryInfo = fGeant4Metadata->GetGeant4GeometryInfo();
+            const auto& geometryInfo = fGeant4Metadata->GetGeant4GeometryInfo();
 
-            const auto physicalVolumes = geometryInfo.GetAllPhysicalVolumesMatchingExpression(volumeSelection);
+            const auto physicalVolumes =
+                geometryInfo.GetAllPhysicalVolumesMatchingExpression(volumeSelection);
             if (physicalVolumes.empty()) {
                 const auto logicalVolumes =
-                        geometryInfo.GetAllLogicalVolumesMatchingExpression(volumeSelection);
-                for (const auto &logicalVolume: logicalVolumes) {
-                    for (const auto &physicalVolume: geometryInfo.GetAllPhysicalVolumesFromLogical(logicalVolume)) {
+                    geometryInfo.GetAllLogicalVolumesMatchingExpression(volumeSelection);
+                for (const auto& logicalVolume : logicalVolumes) {
+                    for (const auto& physicalVolume :
+                         geometryInfo.GetAllPhysicalVolumesFromLogical(logicalVolume)) {
                         physicalVolumes.push_back(
-                                geometryInfo.GetAlternativeNameFromGeant4PhysicalName(physicalVolume));
+                            geometryInfo.GetAlternativeNameFromGeant4PhysicalName(physicalVolume));
                     }
                 }
             }
-            for (const auto &physicalVolume: physicalVolumes) {
+            for (const auto& physicalVolume : physicalVolumes) {
                 volumesToAdd.insert(physicalVolume);
             }
         } else {
             volumesToAdd.insert(volumeSelection);
         }
 
-        for (const auto &volume: volumesToAdd) {
+        for (const auto& volume : volumesToAdd) {
             if (find(fVolumeSelection.begin(), fVolumeSelection.end(), volume) == fVolumeSelection.end()) {
                 fVolumeSelection.push_back(volume);
             }

--- a/src/TRestGeant4ToDetectorHitsProcess.cxx
+++ b/src/TRestGeant4ToDetectorHitsProcess.cxx
@@ -82,7 +82,7 @@ TRestGeant4ToDetectorHitsProcess::TRestGeant4ToDetectorHitsProcess() { Initializ
 ///
 /// \param configFilename A const char* giving the path to an RML file.
 ///
-TRestGeant4ToDetectorHitsProcess::TRestGeant4ToDetectorHitsProcess(const char* configFilename) {
+TRestGeant4ToDetectorHitsProcess::TRestGeant4ToDetectorHitsProcess(const char *configFilename) {
     Initialize();
 
     if (LoadConfigFromFile(configFilename)) LoadDefaultConfig();
@@ -99,7 +99,7 @@ TRestGeant4ToDetectorHitsProcess::~TRestGeant4ToDetectorHitsProcess() { delete f
 void TRestGeant4ToDetectorHitsProcess::LoadDefaultConfig() {
     SetTitle("Default config");
 
-    cout << "G4 to hits metadata not found. Loading default values" << endl;
+    cout << "Geant4 to hits metadata not found. Loading default values" << endl;
 }
 
 ///////////////////////////////////////////////
@@ -110,7 +110,7 @@ void TRestGeant4ToDetectorHitsProcess::Initialize() {
     SetSectionName(this->ClassName());
     SetLibraryVersion(LIBRARY_VERSION);
 
-    fG4Event = nullptr;
+    fGeant4Event = nullptr;
     fHitsEvent = new TRestDetectorHitsEvent();
 }
 
@@ -126,7 +126,7 @@ void TRestGeant4ToDetectorHitsProcess::Initialize() {
 /// \param name The name of the specific metadata. It will be used to find the
 /// corresponding TRestGeant4ToDetectorHitsProcess section inside the RML.
 ///
-void TRestGeant4ToDetectorHitsProcess::LoadConfig(const string& configFilename, const string& name) {
+void TRestGeant4ToDetectorHitsProcess::LoadConfig(const string &configFilename, const string &name) {
     if (LoadConfigFromFile(configFilename, name)) LoadDefaultConfig();
 }
 
@@ -135,13 +135,13 @@ void TRestGeant4ToDetectorHitsProcess::LoadConfig(const string& configFilename, 
 /// TRestGeant4Metadata to identify the geometry volume ids associated to the hits.
 ///
 void TRestGeant4ToDetectorHitsProcess::InitProcess() {
-    fG4Metadata = GetMetadata<TRestGeant4Metadata>();
+    fGeant4Metadata = GetMetadata<TRestGeant4Metadata>();
 
-    for (unsigned int n = 0; n < fVolumeSelection.size(); n++) {
-        if (fG4Metadata->GetActiveVolumeID(fVolumeSelection[n]) >= 0) {
-            fVolumeId.push_back(fG4Metadata->GetActiveVolumeID(fVolumeSelection[n]));
+    for (const auto &userVolume: fVolumeSelection) {
+        if (fGeant4Metadata->GetActiveVolumeID(userVolume) >= 0) {
+            fVolumeId.push_back(fGeant4Metadata->GetActiveVolumeID(userVolume));
         } else if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Warning)
-            cout << "TRestGeant4ToDetectorHitsProcess. volume name : " << fVolumeSelection[n]
+            cout << "TRestGeant4ToDetectorHitsProcess. volume name : " << userVolume
                  << " not found and will not be added." << endl;
     }
 
@@ -150,36 +150,36 @@ void TRestGeant4ToDetectorHitsProcess::InitProcess() {
 
     RESTDebug << "Active volumes available in TRestGeant4Metadata" << RESTendl;
     RESTDebug << "-------------------------------------------" << RESTendl;
-    for (unsigned int n = 0; n < fG4Metadata->GetNumberOfActiveVolumes(); n++) {
-        RESTDebug << "Volume id : " << n << " name : " << fG4Metadata->GetActiveVolumeName(n) << RESTendl;
+    for (unsigned int n = 0; n < fGeant4Metadata->GetNumberOfActiveVolumes(); n++) {
+        RESTDebug << "Volume id : " << n << " name : " << fGeant4Metadata->GetActiveVolumeName(n) << RESTendl;
     }
     RESTDebug << RESTendl;
 
     RESTDebug << "TRestGeant4HitsProcess volumes enabled in RML : ";
     RESTDebug << "-------------------------------------------" << RESTendl;
-    if (fVolumeSelection.size() == 0)
+    if (fVolumeSelection.empty())
         RESTDebug << "all" << RESTendl;
     else {
-        for (unsigned int n = 0; n < fVolumeSelection.size(); n++) {
+        for (const auto &volume: fVolumeSelection) {
             RESTDebug << "" << RESTendl;
-            RESTDebug << " - " << fVolumeSelection[n] << RESTendl;
+            RESTDebug << " - " << volume << RESTendl;
         }
         RESTDebug << " " << RESTendl;
     }
 
-    if (fVolumeSelection.size() > 0 && fVolumeSelection.size() != fVolumeId.size())
+    if (!fVolumeSelection.empty() && fVolumeSelection.size() != fVolumeId.size())
         RESTWarning << "TRestGeant4ToDetectorHitsProcess. Not all volumes were properly identified!"
                     << RESTendl;
 
-    if (fVolumeId.size() > 0) {
+    if (!fVolumeId.empty()) {
         RESTDebug << "TRestGeant4HitsProcess volumes identified : ";
         RESTDebug << "---------------------------------------" << RESTendl;
-        if (fVolumeSelection.size() == 0)
+        if (fVolumeSelection.empty())
             RESTDebug << "all" << RESTendl;
         else
-            for (unsigned int n = 0; n < fVolumeSelection.size(); n++) {
+            for (const auto &volume: fVolumeSelection) {
                 RESTDebug << "" << RESTendl;
-                RESTDebug << " - " << fVolumeSelection[n] << RESTendl;
+                RESTDebug << " - " << volume << RESTendl;
             }
         RESTDebug << " " << RESTendl;
     }
@@ -188,30 +188,30 @@ void TRestGeant4ToDetectorHitsProcess::InitProcess() {
 ///////////////////////////////////////////////
 /// \brief The main processing event function
 ///
-TRestEvent* TRestGeant4ToDetectorHitsProcess::ProcessEvent(TRestEvent* inputEvent) {
-    fG4Event = (TRestGeant4Event*)inputEvent;
+TRestEvent *TRestGeant4ToDetectorHitsProcess::ProcessEvent(TRestEvent *inputEvent) {
+    fGeant4Event = (TRestGeant4Event *) inputEvent;
 
     if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Extreme) {
         cout << "------ TRestGeant4ToDetectorHitsProcess --- Printing Input Event --- START ----" << endl;
-        fG4Event->PrintEvent();
+        fGeant4Event->PrintEvent();
         cout << "------ TRestGeant4ToDetectorHitsProcess --- Printing Input Event ---- END ----" << endl;
         GetChar();
     }
 
-    fHitsEvent->SetRunOrigin(fG4Event->GetRunOrigin());
-    fHitsEvent->SetSubRunOrigin(fG4Event->GetSubRunOrigin());
-    fHitsEvent->SetID(fG4Event->GetID());
-    fHitsEvent->SetSubID(fG4Event->GetSubID());
-    fHitsEvent->SetSubEventTag(fG4Event->GetSubEventTag());
-    fHitsEvent->SetTimeStamp(fG4Event->GetTimeStamp());
-    fHitsEvent->SetState(fG4Event->isOk());
+    fHitsEvent->SetRunOrigin(fGeant4Event->GetRunOrigin());
+    fHitsEvent->SetSubRunOrigin(fGeant4Event->GetSubRunOrigin());
+    fHitsEvent->SetID(fGeant4Event->GetID());
+    fHitsEvent->SetSubID(fGeant4Event->GetSubID());
+    fHitsEvent->SetSubEventTag(fGeant4Event->GetSubEventTag());
+    fHitsEvent->SetTimeStamp(fGeant4Event->GetTimeStamp());
+    fHitsEvent->SetState(fGeant4Event->isOk());
 
-    for (unsigned int i = 0; i < fG4Event->GetNumberOfTracks(); i++) {
-        const auto& track = fG4Event->GetTrack(i);
-        const auto& hits = track.GetHits();
+    for (unsigned int i = 0; i < fGeant4Event->GetNumberOfTracks(); i++) {
+        const auto &track = fGeant4Event->GetTrack(i);
+        const auto &hits = track.GetHits();
         for (unsigned int j = 0; j < track.GetNumberOfHits(); j++) {
             const auto energy = hits.GetEnergy(j);
-            for (const auto& volumeID : fVolumeId) {
+            for (const auto &volumeID: fVolumeId) {
                 if (hits.GetVolumeId(j) == volumeID && energy > 0) {
                     fHitsEvent->AddHit(hits.GetX(j), hits.GetY(j), hits.GetZ(j), energy);
                 }
@@ -236,8 +236,8 @@ TRestEvent* TRestGeant4ToDetectorHitsProcess::ProcessEvent(TRestEvent* inputEven
 ///
 void TRestGeant4ToDetectorHitsProcess::InitFromConfigFile() {
     // Attempt to access TRestGeant4Metadata
-    TRestGeant4Metadata* g4Metadata = GetMetadata<TRestGeant4Metadata>();
-    if (g4Metadata == nullptr) {
+    fGeant4Metadata = GetMetadata<TRestGeant4Metadata>();
+    if (fGeant4Metadata == nullptr) {
         RESTWarning << "TRestGeant4ToDetectorHitsProcess. No TRestGeant4Metadata found in the input file"
                     << RESTendl;
     }
@@ -245,36 +245,36 @@ void TRestGeant4ToDetectorHitsProcess::InitFromConfigFile() {
     size_t position = 0;
     string addVolumeDefinition;
 
-    while ((addVolumeDefinition = GetKEYDefinition("addVolume", position)) != "") {
+    while (!(addVolumeDefinition = GetKEYDefinition("addVolume", position)).empty()) {
         set<string> volumesToAdd;
 
-        const auto volumeSelection = GetFieldValue("name", addVolumeDefinition);
-        if (g4Metadata != nullptr) {
-            const auto& geometryInfo = fGeant4Metadata->GetGeant4GeometryInfo();
+        const auto userVolume = GetFieldValue("name", addVolumeDefinition);
+        if (fGeant4Metadata != nullptr) {
+            const auto &geometryInfo = fGeant4Metadata->GetGeant4GeometryInfo();
 
-            const auto physicalVolumes =
-                geometryInfo.GetAllPhysicalVolumesMatchingExpression(volumeSelection);
+            auto physicalVolumes =
+                    geometryInfo.GetAllPhysicalVolumesMatchingExpression(userVolume);
             if (physicalVolumes.empty()) {
                 const auto logicalVolumes =
-                    geometryInfo.GetAllLogicalVolumesMatchingExpression(volumeSelection);
-                for (const auto& logicalVolume : logicalVolumes) {
-                    for (const auto& physicalVolume :
-                         geometryInfo.GetAllPhysicalVolumesFromLogical(logicalVolume)) {
+                        geometryInfo.GetAllLogicalVolumesMatchingExpression(userVolume);
+                for (const auto &logicalVolume: logicalVolumes) {
+                    for (const auto &physicalVolume:
+                            geometryInfo.GetAllPhysicalVolumesFromLogical(logicalVolume)) {
                         physicalVolumes.push_back(
-                            geometryInfo.GetAlternativeNameFromGeant4PhysicalName(physicalVolume));
+                                geometryInfo.GetAlternativeNameFromGeant4PhysicalName(physicalVolume));
                     }
                 }
             }
-            for (const auto& physicalVolume : physicalVolumes) {
-                volumesToAdd.insert(physicalVolume);
+            for (const auto &physicalVolume: physicalVolumes) {
+                volumesToAdd.insert(physicalVolume.Data());
             }
         } else {
-            volumesToAdd.insert(volumeSelection);
+            volumesToAdd.insert(userVolume);
         }
 
-        for (const auto& volume : volumesToAdd) {
+        for (const auto &volume: volumesToAdd) {
             if (find(fVolumeSelection.begin(), fVolumeSelection.end(), volume) == fVolumeSelection.end()) {
-                fVolumeSelection.push_back(volume);
+                fVolumeSelection.emplace_back(volume);
             }
         }
     }
@@ -286,8 +286,8 @@ void TRestGeant4ToDetectorHitsProcess::InitFromConfigFile() {
 void TRestGeant4ToDetectorHitsProcess::PrintMetadata() {
     BeginPrintProcess();
 
-    for (unsigned int n = 0; n < fVolumeSelection.size(); n++) {
-        RESTMetadata << "Volume added : " << fVolumeSelection[n] << RESTendl;
+    for (const auto &volume: fVolumeSelection) {
+        RESTMetadata << "Volume added : " << volume << RESTendl;
     }
 
     EndPrintProcess();

--- a/src/TRestGeant4ToDetectorHitsProcess.cxx
+++ b/src/TRestGeant4ToDetectorHitsProcess.cxx
@@ -82,7 +82,7 @@ TRestGeant4ToDetectorHitsProcess::TRestGeant4ToDetectorHitsProcess() { Initializ
 ///
 /// \param configFilename A const char* giving the path to an RML file.
 ///
-TRestGeant4ToDetectorHitsProcess::TRestGeant4ToDetectorHitsProcess(const char *configFilename) {
+TRestGeant4ToDetectorHitsProcess::TRestGeant4ToDetectorHitsProcess(const char* configFilename) {
     Initialize();
 
     if (LoadConfigFromFile(configFilename)) LoadDefaultConfig();
@@ -126,7 +126,7 @@ void TRestGeant4ToDetectorHitsProcess::Initialize() {
 /// \param name The name of the specific metadata. It will be used to find the
 /// corresponding TRestGeant4ToDetectorHitsProcess section inside the RML.
 ///
-void TRestGeant4ToDetectorHitsProcess::LoadConfig(const string &configFilename, const string &name) {
+void TRestGeant4ToDetectorHitsProcess::LoadConfig(const string& configFilename, const string& name) {
     if (LoadConfigFromFile(configFilename, name)) LoadDefaultConfig();
 }
 
@@ -137,7 +137,7 @@ void TRestGeant4ToDetectorHitsProcess::LoadConfig(const string &configFilename, 
 void TRestGeant4ToDetectorHitsProcess::InitProcess() {
     fGeant4Metadata = GetMetadata<TRestGeant4Metadata>();
 
-    for (const auto &userVolume: fVolumeSelection) {
+    for (const auto& userVolume : fVolumeSelection) {
         if (fGeant4Metadata->GetActiveVolumeID(userVolume) >= 0) {
             fVolumeId.push_back(fGeant4Metadata->GetActiveVolumeID(userVolume));
         } else if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Warning)
@@ -160,7 +160,7 @@ void TRestGeant4ToDetectorHitsProcess::InitProcess() {
     if (fVolumeSelection.empty())
         RESTDebug << "all" << RESTendl;
     else {
-        for (const auto &volume: fVolumeSelection) {
+        for (const auto& volume : fVolumeSelection) {
             RESTDebug << "" << RESTendl;
             RESTDebug << " - " << volume << RESTendl;
         }
@@ -177,7 +177,7 @@ void TRestGeant4ToDetectorHitsProcess::InitProcess() {
         if (fVolumeSelection.empty())
             RESTDebug << "all" << RESTendl;
         else
-            for (const auto &volume: fVolumeSelection) {
+            for (const auto& volume : fVolumeSelection) {
                 RESTDebug << "" << RESTendl;
                 RESTDebug << " - " << volume << RESTendl;
             }
@@ -188,8 +188,8 @@ void TRestGeant4ToDetectorHitsProcess::InitProcess() {
 ///////////////////////////////////////////////
 /// \brief The main processing event function
 ///
-TRestEvent *TRestGeant4ToDetectorHitsProcess::ProcessEvent(TRestEvent *inputEvent) {
-    fGeant4Event = (TRestGeant4Event *) inputEvent;
+TRestEvent* TRestGeant4ToDetectorHitsProcess::ProcessEvent(TRestEvent* inputEvent) {
+    fGeant4Event = (TRestGeant4Event*)inputEvent;
 
     if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Extreme) {
         cout << "------ TRestGeant4ToDetectorHitsProcess --- Printing Input Event --- START ----" << endl;
@@ -207,11 +207,11 @@ TRestEvent *TRestGeant4ToDetectorHitsProcess::ProcessEvent(TRestEvent *inputEven
     fHitsEvent->SetState(fGeant4Event->isOk());
 
     for (unsigned int i = 0; i < fGeant4Event->GetNumberOfTracks(); i++) {
-        const auto &track = fGeant4Event->GetTrack(i);
-        const auto &hits = track.GetHits();
+        const auto& track = fGeant4Event->GetTrack(i);
+        const auto& hits = track.GetHits();
         for (unsigned int j = 0; j < track.GetNumberOfHits(); j++) {
             const auto energy = hits.GetEnergy(j);
-            for (const auto &volumeID: fVolumeId) {
+            for (const auto& volumeID : fVolumeId) {
                 if (hits.GetVolumeId(j) == volumeID && energy > 0) {
                     fHitsEvent->AddHit(hits.GetX(j), hits.GetY(j), hits.GetZ(j), energy);
                 }
@@ -243,13 +243,13 @@ void TRestGeant4ToDetectorHitsProcess::InitFromConfigFile() {
     }
 
     set<string> volumesToAdd;
-    TiXmlElement *volumeDefinition = GetElement("volume");
+    TiXmlElement* volumeDefinition = GetElement("volume");
     if (volumeDefinition == nullptr) {
         volumeDefinition = GetElement("addVolume");
         if (volumeDefinition != nullptr) {
-            RESTWarning
-                    << "TRestGeant4ToDetectorHitsProcess. 'addVolume' tag is deprecated. Please use 'volume' instead."
-                    << RESTendl;
+            RESTWarning << "TRestGeant4ToDetectorHitsProcess. 'addVolume' tag is deprecated. Please use "
+                           "'volume' instead."
+                        << RESTendl;
         }
     }
     while (volumeDefinition != nullptr) {
@@ -258,22 +258,20 @@ void TRestGeant4ToDetectorHitsProcess::InitFromConfigFile() {
             RESTError << "TRestGeant4ToDetectorHitsProcess. No name defined for volume" << RESTendl;
         }
         if (fGeant4Metadata != nullptr) {
-            const auto &geometryInfo = fGeant4Metadata->GetGeant4GeometryInfo();
+            const auto& geometryInfo = fGeant4Metadata->GetGeant4GeometryInfo();
 
-            auto physicalVolumes =
-                    geometryInfo.GetAllPhysicalVolumesMatchingExpression(userVolume);
+            auto physicalVolumes = geometryInfo.GetAllPhysicalVolumesMatchingExpression(userVolume);
             if (physicalVolumes.empty()) {
-                const auto logicalVolumes =
-                        geometryInfo.GetAllLogicalVolumesMatchingExpression(userVolume);
-                for (const auto &logicalVolume: logicalVolumes) {
-                    for (const auto &physicalVolume:
-                            geometryInfo.GetAllPhysicalVolumesFromLogical(logicalVolume)) {
+                const auto logicalVolumes = geometryInfo.GetAllLogicalVolumesMatchingExpression(userVolume);
+                for (const auto& logicalVolume : logicalVolumes) {
+                    for (const auto& physicalVolume :
+                         geometryInfo.GetAllPhysicalVolumesFromLogical(logicalVolume)) {
                         physicalVolumes.push_back(
-                                geometryInfo.GetAlternativeNameFromGeant4PhysicalName(physicalVolume));
+                            geometryInfo.GetAlternativeNameFromGeant4PhysicalName(physicalVolume));
                     }
                 }
             }
-            for (const auto &physicalVolume: physicalVolumes) {
+            for (const auto& physicalVolume : physicalVolumes) {
                 volumesToAdd.insert(physicalVolume.Data());
             }
         } else {
@@ -283,7 +281,7 @@ void TRestGeant4ToDetectorHitsProcess::InitFromConfigFile() {
         volumeDefinition = GetNextElement(volumeDefinition);
     }
 
-    for (const auto &volume: volumesToAdd) {
+    for (const auto& volume : volumesToAdd) {
         if (find(fVolumeSelection.begin(), fVolumeSelection.end(), volume) == fVolumeSelection.end()) {
             fVolumeSelection.emplace_back(volume);
         }
@@ -296,7 +294,7 @@ void TRestGeant4ToDetectorHitsProcess::InitFromConfigFile() {
 void TRestGeant4ToDetectorHitsProcess::PrintMetadata() {
     BeginPrintProcess();
 
-    for (const auto &volume: fVolumeSelection) {
+    for (const auto& volume : fVolumeSelection) {
         RESTMetadata << "Volume added : " << volume << RESTendl;
     }
 

--- a/src/TRestGeant4ToDetectorHitsProcess.cxx
+++ b/src/TRestGeant4ToDetectorHitsProcess.cxx
@@ -82,7 +82,7 @@ TRestGeant4ToDetectorHitsProcess::TRestGeant4ToDetectorHitsProcess() { Initializ
 ///
 /// \param configFilename A const char* giving the path to an RML file.
 ///
-TRestGeant4ToDetectorHitsProcess::TRestGeant4ToDetectorHitsProcess(const char* configFilename) {
+TRestGeant4ToDetectorHitsProcess::TRestGeant4ToDetectorHitsProcess(const char *configFilename) {
     Initialize();
 
     if (LoadConfigFromFile(configFilename)) LoadDefaultConfig();
@@ -126,7 +126,7 @@ void TRestGeant4ToDetectorHitsProcess::Initialize() {
 /// \param name The name of the specific metadata. It will be used to find the
 /// corresponding TRestGeant4ToDetectorHitsProcess section inside the RML.
 ///
-void TRestGeant4ToDetectorHitsProcess::LoadConfig(const string& configFilename, const string& name) {
+void TRestGeant4ToDetectorHitsProcess::LoadConfig(const string &configFilename, const string &name) {
     if (LoadConfigFromFile(configFilename, name)) LoadDefaultConfig();
 }
 
@@ -188,8 +188,8 @@ void TRestGeant4ToDetectorHitsProcess::InitProcess() {
 ///////////////////////////////////////////////
 /// \brief The main processing event function
 ///
-TRestEvent* TRestGeant4ToDetectorHitsProcess::ProcessEvent(TRestEvent* inputEvent) {
-    fG4Event = (TRestGeant4Event*)inputEvent;
+TRestEvent *TRestGeant4ToDetectorHitsProcess::ProcessEvent(TRestEvent *inputEvent) {
+    fG4Event = (TRestGeant4Event *) inputEvent;
 
     if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Extreme) {
         cout << "------ TRestGeant4ToDetectorHitsProcess --- Printing Input Event --- START ----" << endl;
@@ -207,11 +207,11 @@ TRestEvent* TRestGeant4ToDetectorHitsProcess::ProcessEvent(TRestEvent* inputEven
     fHitsEvent->SetState(fG4Event->isOk());
 
     for (unsigned int i = 0; i < fG4Event->GetNumberOfTracks(); i++) {
-        const auto& track = fG4Event->GetTrack(i);
-        const auto& hits = track.GetHits();
+        const auto &track = fG4Event->GetTrack(i);
+        const auto &hits = track.GetHits();
         for (unsigned int j = 0; j < track.GetNumberOfHits(); j++) {
             const auto energy = hits.GetEnergy(j);
-            for (const auto& volumeID : fVolumeId) {
+            for (const auto &volumeID: fVolumeId) {
                 if (hits.GetVolumeId(j) == volumeID && energy > 0) {
                     fHitsEvent->AddHit(hits.GetX(j), hits.GetY(j), hits.GetZ(j), energy);
                 }
@@ -235,11 +235,46 @@ TRestEvent* TRestGeant4ToDetectorHitsProcess::ProcessEvent(TRestEvent* inputEven
 /// TRestGeant4ToDetectorHitsProcess metadata section
 ///
 void TRestGeant4ToDetectorHitsProcess::InitFromConfigFile() {
+    // Attempt to access TRestGeant4Metadata
+    TRestGeant4Metadata *g4Metadata = GetMetadata<TRestGeant4Metadata>();
+    if (g4Metadata == nullptr) {
+        RESTWarning << "TRestGeant4ToDetectorHitsProcess. No TRestGeant4Metadata found in the input file" << RESTendl;
+    }
+
     size_t position = 0;
     string addVolumeDefinition;
 
-    while ((addVolumeDefinition = GetKEYDefinition("addVolume", position)) != "")
-        fVolumeSelection.push_back(GetFieldValue("name", addVolumeDefinition));
+    while ((addVolumeDefinition = GetKEYDefinition("addVolume", position)) != "") {
+        set <string> volumesToAdd;
+
+        const auto volumeSelection = GetFieldValue("name", addVolumeDefinition);
+        if (g4Metadata != nullptr) {
+            const auto &geometryInfo = fGeant4Metadata->GetGeant4GeometryInfo();
+
+            const auto physicalVolumes = geometryInfo.GetAllPhysicalVolumesMatchingExpression(volumeSelection);
+            if (physicalVolumes.empty()) {
+                const auto logicalVolumes =
+                        geometryInfo.GetAllLogicalVolumesMatchingExpression(volumeSelection);
+                for (const auto &logicalVolume: logicalVolumes) {
+                    for (const auto &physicalVolume: geometryInfo.GetAllPhysicalVolumesFromLogical(logicalVolume)) {
+                        physicalVolumes.push_back(
+                                geometryInfo.GetAlternativeNameFromGeant4PhysicalName(physicalVolume));
+                    }
+                }
+            }
+            for (const auto &physicalVolume: physicalVolumes) {
+                volumesToAdd.insert(physicalVolume);
+            }
+        } else {
+            volumesToAdd.insert(volumeSelection);
+        }
+
+        for (const auto &volume: volumesToAdd) {
+            if (find(fVolumeSelection.begin(), fVolumeSelection.end(), volume) == fVolumeSelection.end()) {
+                fVolumeSelection.push_back(volume);
+            }
+        }
+    }
 }
 
 ///////////////////////////////////////////////

--- a/src/TRestGeant4ToDetectorHitsProcess.cxx
+++ b/src/TRestGeant4ToDetectorHitsProcess.cxx
@@ -23,7 +23,7 @@
 //////////////////////////////////////////////////////////////////////////
 /// This process allows to select the GDML geometry volumes (defined in
 /// TRestGeant4Metadata) that will be transferred to the TRestDetectorHitsEvent by
-/// using the `<addVolume` key inside the process definition.
+/// using the `<volume` key inside the process definition.
 ///
 /// The following example shows how to include the process into
 /// `TRestProcessRunner` RML definition. In this particular example we
@@ -33,12 +33,12 @@
 /// \code
 ///
 /// <addProcess type="TRestGeant4ToDetectorHitsProcess" name="g4ToHits" value="ON">
-///     <addVolume name="gas" />
-///     <addVolume name="vessel" />
+///     <volume name="gas"/>
+///     <volume name="vessel"/>
 /// </addProcess>
 /// \endcode
 ///
-/// If no volumes are defined using the `<addVolume` key, **all volumes will
+/// If no volumes are defined using the `<volume` key, **all volumes will
 /// be active**, and all hits will be transferred to the TRestDetectorHitsEvent output.
 ///
 ///--------------------------------------------------------------------------
@@ -243,7 +243,15 @@ void TRestGeant4ToDetectorHitsProcess::InitFromConfigFile() {
     }
 
     set<string> volumesToAdd;
-    TiXmlElement *volumeDefinition = GetElement("addVolume");
+    TiXmlElement *volumeDefinition = GetElement("volume");
+    if (volumeDefinition == nullptr) {
+        volumeDefinition = GetElement("addVolume");
+        if (volumeDefinition != nullptr) {
+            RESTWarning
+                    << "TRestGeant4ToDetectorHitsProcess. 'addVolume' tag is deprecated. Please use 'volume' instead."
+                    << RESTendl;
+        }
+    }
     while (volumeDefinition != nullptr) {
         const auto userVolume = GetFieldValue("name", volumeDefinition);
         if (userVolume == "Not defined") {

--- a/src/TRestGeant4ToDetectorHitsProcess.cxx
+++ b/src/TRestGeant4ToDetectorHitsProcess.cxx
@@ -242,13 +242,13 @@ void TRestGeant4ToDetectorHitsProcess::InitFromConfigFile() {
                     << RESTendl;
     }
 
-    size_t position = 0;
-    string addVolumeDefinition;
-
-    while (!(addVolumeDefinition = GetKEYDefinition("addVolume", position)).empty()) {
-        set<string> volumesToAdd;
-
-        const auto userVolume = GetFieldValue("name", addVolumeDefinition);
+    set<string> volumesToAdd;
+    TiXmlElement *volumeDefinition = GetElement("addVolume");
+    while (volumeDefinition != nullptr) {
+        const auto userVolume = GetFieldValue("name", volumeDefinition);
+        if (userVolume == "Not defined") {
+            RESTError << "TRestGeant4ToDetectorHitsProcess. No name defined for volume" << RESTendl;
+        }
         if (fGeant4Metadata != nullptr) {
             const auto &geometryInfo = fGeant4Metadata->GetGeant4GeometryInfo();
 
@@ -272,10 +272,12 @@ void TRestGeant4ToDetectorHitsProcess::InitFromConfigFile() {
             volumesToAdd.insert(userVolume);
         }
 
-        for (const auto &volume: volumesToAdd) {
-            if (find(fVolumeSelection.begin(), fVolumeSelection.end(), volume) == fVolumeSelection.end()) {
-                fVolumeSelection.emplace_back(volume);
-            }
+        volumeDefinition = GetNextElement(volumeDefinition);
+    }
+
+    for (const auto &volume: volumesToAdd) {
+        if (find(fVolumeSelection.begin(), fVolumeSelection.end(), volume) == fVolumeSelection.end()) {
+            fVolumeSelection.emplace_back(volume);
         }
     }
 }


### PR DESCRIPTION
![lobis](https://badgen.net/badge/PR%20submitted%20by%3A/lobis/blue) ![Ok: 95](https://badgen.net/badge/PR%20Size/Ok%3A%2095/green) [![](https://gitlab.cern.ch/rest-for-physics/framework/badges/lobis-volumes/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/framework/-/commits/lobis-volumes)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Modified the `TRestGeant4ToDetectorHitsProcess` process with some changes:

- Repeated volumes are not counted multiple times (are just ignored).
- Volumes can now also be specified by logical volume name or by expression to select multiple volumes at once.
- Updated the xml tag from `addVolume` to `volume` to increase coherence in naming but I kept backwards compatiblity with the old `addVolume`. Documentation has been updated to this new tag.