### PR TITLE
Removal of custom typedef any since it is misleading with std::any

### DIFF
--- a/inc/TRestDetectorHitsToTrackFastProcess.h
+++ b/inc/TRestDetectorHitsToTrackFastProcess.h
@@ -38,8 +38,8 @@ class TRestDetectorHitsToTrackFastProcess : public TRestEventProcess {
     Int_t fNodes;
 
    public:
-    any GetInputEvent() const override { return fHitsEvent; }
-    any GetOutputEvent() const override { return fTrackEvent; }
+    RESTValue GetInputEvent() const override { return fHitsEvent; }
+    RESTValue GetOutputEvent() const override { return fTrackEvent; }
 
     void InitProcess() override;
     TRestEvent* ProcessEvent(TRestEvent* inputEvent) override;

--- a/inc/TRestDetectorHitsToTrackProcess.h
+++ b/inc/TRestDetectorHitsToTrackProcess.h
@@ -45,8 +45,8 @@ class TRestDetectorHitsToTrackProcess : public TRestEventProcess {
     Double_t fClusterDistance = 2.5;
 
    public:
-    any GetInputEvent() const override { return fHitsEvent; }
-    any GetOutputEvent() const override { return fTrackEvent; }
+    RESTValue GetInputEvent() const override { return fHitsEvent; }
+    RESTValue GetOutputEvent() const override { return fTrackEvent; }
 
     TRestEvent* ProcessEvent(TRestEvent* inputEvent) override;
 

--- a/inc/TRestDetectorSignalToRawSignalProcess.h
+++ b/inc/TRestDetectorSignalToRawSignalProcess.h
@@ -115,8 +115,8 @@ class TRestDetectorSignalToRawSignalProcess : public TRestEventProcess {
     inline TVector2 GetCalibrationRange() const { return fCalibrationRange; }
     inline void SetCalibrationRange(TVector2 calibrationRange) { fCalibrationRange = calibrationRange; }
 
-    any GetInputEvent() const override { return fInputSignalEvent; }
-    any GetOutputEvent() const override { return fOutputRawSignalEvent; }
+    RESTValue GetInputEvent() const override { return fInputSignalEvent; }
+    RESTValue GetOutputEvent() const override { return fOutputRawSignalEvent; }
 
     void InitProcess() override;
 

--- a/inc/TRestGeant4ToDetectorHitsProcess.h
+++ b/inc/TRestGeant4ToDetectorHitsProcess.h
@@ -57,9 +57,9 @@ class TRestGeant4ToDetectorHitsProcess : public TRestEventProcess {
     // add here the members of your event process
 
    public:
-    any GetInputEvent() const override { return fGeant4Event; }
+    RESTValue GetInputEvent() const override { return fGeant4Event; }
 
-    any GetOutputEvent() const override { return fHitsEvent; }
+    RESTValue GetOutputEvent() const override { return fHitsEvent; }
 
     void InitProcess() override;
 

--- a/inc/TRestRawReadoutAnalysisProcess.h
+++ b/inc/TRestRawReadoutAnalysisProcess.h
@@ -47,8 +47,8 @@ class TRestRawReadoutAnalysisProcess : public TRestEventProcess {
                                             //
 
    public:
-    any GetInputEvent() const override { return fSignalEvent; }
-    any GetOutputEvent() const override { return fSignalEvent; }
+    RESTValue GetInputEvent() const override { return fSignalEvent; }
+    RESTValue GetOutputEvent() const override { return fSignalEvent; }
 
     void InitProcess() override;
     TRestEvent* ProcessEvent(TRestEvent* inputEvent) override;

--- a/inc/TRestRawToDetectorSignalProcess.h
+++ b/inc/TRestRawToDetectorSignalProcess.h
@@ -74,8 +74,8 @@ class TRestRawToDetectorSignalProcess : public TRestEventProcess {
     Bool_t fBaseLineCorrection = false;
 
    public:
-    any GetInputEvent() const override { return fInputSignalEvent; }
-    any GetOutputEvent() const override { return fOutputSignalEvent; }
+    RESTValue GetInputEvent() const override { return fInputSignalEvent; }
+    RESTValue GetOutputEvent() const override { return fOutputSignalEvent; }
 
     TRestEvent* ProcessEvent(TRestEvent* inputEvent) override;
 

--- a/inc/TRestTrackToDetectorHitsProcess.h
+++ b/inc/TRestTrackToDetectorHitsProcess.h
@@ -32,8 +32,8 @@ class TRestTrackToDetectorHitsProcess : public TRestEventProcess {
     Int_t fTrackLevel;
 
    public:
-    any GetInputEvent() const override { return fInputTrackEvent; }
-    any GetOutputEvent() const override { return fOutputHitsEvent; }
+    RESTValue GetInputEvent() const override { return fInputTrackEvent; }
+    RESTValue GetOutputEvent() const override { return fOutputHitsEvent; }
 
     void InitProcess() override;
     TRestEvent* ProcessEvent(TRestEvent* inputEvent) override;


### PR DESCRIPTION
![juanangp](https://badgen.net/badge/PR%20submitted%20by%3A/juanangp/blue) ![Ok: 14](https://badgen.net/badge/PR%20Size/Ok%3A%2014/green) [![](https://gitlab.cern.ch/rest-for-physics/framework/badges/any_to_RESTValue/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/framework/-/commits/any_to_RESTValue) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=rest-for-physics&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Removal of custom `typedef REST_Reflection::TRestReflector any` since it is misleading with `std::any`.

The custom typedef `any` has been replaced by existing `typedef REST_Reflection::TRestReflector RESTValue`

Related PR https://github.com/rest-for-physics/framework/pull/471