### PR TITLE
Negative times

### DIFF
--- a/src/TRestDetectorSignalToRawSignalProcess.cxx
+++ b/src/TRestDetectorSignalToRawSignalProcess.cxx
@@ -250,9 +250,10 @@ TRestEvent* TRestDetectorSignalToRawSignalProcess::ProcessEvent(TRestEvent* inpu
     RESTDebug << "fTimeStart : " << fTimeStart << " us " << RESTendl;
     RESTDebug << "fTimeEnd : " << fTimeEnd << " us " << RESTendl;
 
-    if (fTimeStart < 0) {
-        // This should never happen
-        cerr << "fTimeStart < 0" << endl;
+    if (fTimeStart + fTriggerDelay * fSampling < 0) {
+        // This means something is wrong (negative times somewhere). This should never happen
+        cerr << "TRestDetectorSignalToRawSignalProcess::ProcessEvent: "
+             << "fTimeStart < - fTriggerDelay * fSampling" << endl;
         exit(1);
     }
 

--- a/src/TRestDetectorSignalToRawSignalProcess.cxx
+++ b/src/TRestDetectorSignalToRawSignalProcess.cxx
@@ -250,6 +250,12 @@ TRestEvent* TRestDetectorSignalToRawSignalProcess::ProcessEvent(TRestEvent* inpu
     RESTDebug << "fTimeStart : " << fTimeStart << " us " << RESTendl;
     RESTDebug << "fTimeEnd : " << fTimeEnd << " us " << RESTendl;
 
+    if (fTimeStart < 0) {
+        // This should never happen
+        cerr << "fTimeStart < 0" << endl;
+        exit(1);
+    }
+
     for (int n = 0; n < fInputSignalEvent->GetNumberOfSignals(); n++) {
         vector<Double_t> data(fNPoints, fCalibrationOffset);
         TRestDetectorSignal* signal = fInputSignalEvent->GetSignal(n);

--- a/src/TRestDetectorSignalToRawSignalProcess.cxx
+++ b/src/TRestDetectorSignalToRawSignalProcess.cxx
@@ -252,8 +252,8 @@ TRestEvent* TRestDetectorSignalToRawSignalProcess::ProcessEvent(TRestEvent* inpu
 
     if (fTimeStart + fTriggerDelay * fSampling < 0) {
         // This means something is wrong (negative times somewhere). This should never happen
-        cerr << "TRestDetectorSignalToRawSignalProcess::ProcessEvent: "
-             << "fTimeStart < - fTriggerDelay * fSampling" << endl;
+        RESTError << "TRestDetectorSignalToRawSignalProcess::ProcessEvent: "
+                  << "fTimeStart < - fTriggerDelay * fSampling" << RESTendl;
         exit(1);
     }
 


### PR DESCRIPTION
![lobis](https://badgen.net/badge/PR%20submitted%20by%3A/lobis/blue) ![Ok: 7](https://badgen.net/badge/PR%20Size/Ok%3A%207/green) [![](https://gitlab.cern.ch/rest-for-physics/framework/badges/lobis-time-start/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/framework/-/commits/lobis-time-start) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=rest-for-physics&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

I noticed that when using the `TRestDetectorSignalToRawSignalProcess` wit the option `firstDeposit` with simulation data produced using `restG4` which contains some hit with a large time (such as `1E8`) something glitches and the signal minimum time is returned as negative.

I added a check here that exits if this error is present so it never happens in the future, but I could not find the exact cause of the problem. Perhaps @jgalan has some idea what is going on.

- https://github.com/rest-for-physics/detectorlib/pull/101