### PR TITLE
TRestDetectorSignalToRawSignalProcess adding optional noise process 

### DIFF
--- a/inc/TRestDetectorSignalToRawSignalProcess.h
+++ b/inc/TRestDetectorSignalToRawSignalProcess.h
@@ -83,6 +83,9 @@ class TRestDetectorSignalToRawSignalProcess : public TRestEventProcess {
     /// avoid artifacts in the signal (e.g. signals not getting cut when they should)
     Double_t fShapingTime = 0.0;  // us
 
+    //Noise level
+    Double_t fNoiseLevel = 0.0;
+
    public:
     inline Double_t GetSampling() const { return fSampling; }
 
@@ -118,6 +121,7 @@ class TRestDetectorSignalToRawSignalProcess : public TRestEventProcess {
         Double_t shapingTime = 0.0;
         Double_t calibrationGain = 100;
         Double_t calibrationOffset = 0;
+        Double_t noiseLevel = 0.0;
         TVector2 calibrationEnergy = {0, 0};
         TVector2 calibrationRange = {0, 0};
     };

--- a/inc/TRestDetectorSignalToRawSignalProcess.h
+++ b/inc/TRestDetectorSignalToRawSignalProcess.h
@@ -141,19 +141,17 @@ class TRestDetectorSignalToRawSignalProcess : public TRestEventProcess {
     /// Returns the name of this process
     const char* GetProcessName() const override { return "signalToRawSignal"; }
 
-    // Constructor
     TRestDetectorSignalToRawSignalProcess();
 
-    TRestDetectorSignalToRawSignalProcess(const char* configFilename);
+    explicit TRestDetectorSignalToRawSignalProcess(const char* configFilename);
 
-    // Destructor
-    ~TRestDetectorSignalToRawSignalProcess();
+    ~TRestDetectorSignalToRawSignalProcess() override;
 
    private:
     std::map<std::string, Parameters> fParametersMap;
     std::set<std::string> fReadoutTypes;
 
-    ClassDefOverride(TRestDetectorSignalToRawSignalProcess, 7);
+    ClassDefOverride(TRestDetectorSignalToRawSignalProcess, 8);
 };
 
 #endif

--- a/inc/TRestDetectorSignalToRawSignalProcess.h
+++ b/inc/TRestDetectorSignalToRawSignalProcess.h
@@ -83,7 +83,7 @@ class TRestDetectorSignalToRawSignalProcess : public TRestEventProcess {
     /// avoid artifacts in the signal (e.g. signals not getting cut when they should)
     Double_t fShapingTime = 0.0;  // us
 
-    //Noise level
+    // Noise level
     Double_t fNoiseLevel = 0.0;
 
    public:

--- a/src/TRestDetectorSignalToRawSignalProcess.cxx
+++ b/src/TRestDetectorSignalToRawSignalProcess.cxx
@@ -696,7 +696,7 @@ void TRestDetectorSignalToRawSignalProcess::PrintMetadata() {
             RESTMetadata << "Shaping time: " << shapingTime * 1000 << " ns" << RESTendl;
         }
         const double noiseLevel = fParametersMap.at(readoutType).noiseLevel;
-        if(noiseLevel > 0){
+        if (noiseLevel > 0) {
             RESTMetadata << "Noise Level: " << noiseLevel << RESTendl;
         }
 

--- a/src/TRestDetectorSignalToRawSignalProcess.cxx
+++ b/src/TRestDetectorSignalToRawSignalProcess.cxx
@@ -421,7 +421,7 @@ TRestEvent* TRestDetectorSignalToRawSignalProcess::ProcessEvent(TRestEvent* inpu
 
             if (t > timeStart && t < timeEnd) {
                 // convert physical time (in us) to timeBin
-                Int_t timeBin = (Int_t)round((t - timeStart) / sampling);
+                auto timeBin = (Int_t)round((t - timeStart) / sampling);
 
                 if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Warning) {
                     if (timeBin < 0 || timeBin > fNPoints) {
@@ -432,6 +432,13 @@ TRestEvent* TRestDetectorSignalToRawSignalProcess::ProcessEvent(TRestEvent* inpu
 
                 RESTDebug << "Adding data: " << signal->GetData(m) << " to Time Bin: " << timeBin << RESTendl;
                 data[timeBin] += calibrationGain * signal->GetData(m);
+            }
+        }
+
+        // Noise before shaping
+        if (noiseLevel > 0) {
+            for (int i = 0; i < fNPoints; i++) {
+                data[i] += gRandom->Gaus(0, noiseLevel);
             }
         }
 
@@ -467,6 +474,13 @@ TRestEvent* TRestDetectorSignalToRawSignalProcess::ProcessEvent(TRestEvent* inpu
                 }
             }
             data = dataAfterShaping;
+
+            // Noise after shaping
+            if (noiseLevel > 0) {
+                for (int i = 0; i < fNPoints; i++) {
+                    data[i] += gRandom->Gaus(0, noiseLevel);
+                }
+            }
         }
 
         TRestRawSignal rawSignal;

--- a/src/TRestDetectorSignalToRawSignalProcess.cxx
+++ b/src/TRestDetectorSignalToRawSignalProcess.cxx
@@ -695,6 +695,10 @@ void TRestDetectorSignalToRawSignalProcess::PrintMetadata() {
         if (shapingTime > 0) {
             RESTMetadata << "Shaping time: " << shapingTime * 1000 << " ns" << RESTendl;
         }
+        const double noiseLevel = fParametersMap.at(readoutType).noiseLevel;
+        if(noiseLevel > 0){
+            RESTMetadata << "Noise Level: " << noiseLevel << RESTendl;
+        }
 
         if (IsLinearCalibration()) {
             RESTMetadata << "Calibration energies: (" << fParametersMap.at(readoutType).calibrationEnergy.X()

--- a/src/TRestDetectorSignalToRawSignalProcess.cxx
+++ b/src/TRestDetectorSignalToRawSignalProcess.cxx
@@ -381,6 +381,7 @@ TRestEvent* TRestDetectorSignalToRawSignalProcess::ProcessEvent(TRestEvent* inpu
             type = "";
         }
 
+        double noiseLevel = fParametersMap.at(type).noiseLevel;
         double sampling = fParametersMap.at(type).sampling;
         double shapingTime = fParametersMap.at(type).shapingTime;
         double calibrationGain = fParametersMap.at(type).calibrationGain;
@@ -547,6 +548,8 @@ void TRestDetectorSignalToRawSignalProcess::InitFromConfigFile() {
             Get2DVectorParameterWithUnits("calibrationEnergy" + typeCamelCase, parameters.calibrationEnergy);
         parameters.calibrationRange =
             Get2DVectorParameterWithUnits("calibrationRange" + typeCamelCase, parameters.calibrationRange);
+        parameters.noiseLevel =
+            GetDblParameterWithUnits("noiseLevel" + typeCamelCase, parameters.noiseLevel);
 
         const bool isLinearCalibration =
             (parameters.calibrationEnergy.Mod() != 0 && parameters.calibrationRange.Mod() != 0);

--- a/src/TRestDetectorSignalToRawSignalProcess.cxx
+++ b/src/TRestDetectorSignalToRawSignalProcess.cxx
@@ -548,8 +548,7 @@ void TRestDetectorSignalToRawSignalProcess::InitFromConfigFile() {
             Get2DVectorParameterWithUnits("calibrationEnergy" + typeCamelCase, parameters.calibrationEnergy);
         parameters.calibrationRange =
             Get2DVectorParameterWithUnits("calibrationRange" + typeCamelCase, parameters.calibrationRange);
-        parameters.noiseLevel =
-            GetDblParameterWithUnits("noiseLevel" + typeCamelCase, parameters.noiseLevel);
+        parameters.noiseLevel = GetDblParameterWithUnits("noiseLevel" + typeCamelCase, parameters.noiseLevel);
 
         const bool isLinearCalibration =
             (parameters.calibrationEnergy.Mod() != 0 && parameters.calibrationRange.Mod() != 0);

--- a/src/TRestDetectorSignalToRawSignalProcess.cxx
+++ b/src/TRestDetectorSignalToRawSignalProcess.cxx
@@ -615,6 +615,7 @@ void TRestDetectorSignalToRawSignalProcess::InitFromConfigFile() {
     // load default parameters (for backward compatibility)
     fSampling = fParametersMap.at(defaultType).sampling;
     fShapingTime = fParametersMap.at(defaultType).shapingTime;
+    fNoiseLevel = fParametersMap.at(defaultType).noiseLevel;
     fCalibrationGain = fParametersMap.at(defaultType).calibrationGain;
     fCalibrationOffset = fParametersMap.at(defaultType).calibrationOffset;
     fCalibrationEnergy = fParametersMap.at(defaultType).calibrationEnergy;


### PR DESCRIPTION
![mariajmz](https://badgen.net/badge/PR%20submitted%20by%3A/mariajmz/blue) ![Ok: 29](https://badgen.net/badge/PR%20Size/Ok%3A%2029/green) [![](https://gitlab.cern.ch/rest-for-physics/framework/badges/mariajmz_raw_noise/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/framework/-/commits/mariajmz_raw_noise) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=rest-for-physics&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Adding optional noise process **before** and **after** the shaping process. For the moment, it applies the same `noiseLevel` before and after the shaping.

To use it, in the rml the user must specify `noiseLevel` for each type of signal tpc `noiseLevelTpc` and/or veto `noiseLevelVeto`. Here we show an example of the rml section:

``` xml
<addProcess type="TRestDetectorSignalToRawSignalProcess" name="DetectorSignalToRaw" value="ON">   
            <parameter name="nPoints" value="512"/>
            <parameter name="triggerMode" value="integralThresholdTPC"/>
            <parameter name="triggerDelay" value="127"/>
            <parameter name="integralThresholdTPCkeV" value="0.1"/>
            <observable name="triggerTimeTPC" value="ON"/>
            <parameter name="readoutTypes" value="tpc,veto"/>

            <parameter name="samplingTpc" value="20ns"/>
            <parameter name="shapingTimeTpc" value="1200ns"/> 
            <parameter name="noiseLevelTpc" value="10"/>
            <parameter name="calibrationEnergyTpc" value="(0,1.83)keV"/>        
            <parameter name="calibrationRangeTpc" value="(0.05,0.5)"/>

            <parameter name="samplingVeto" value="500ns"/>
            <parameter name="shapingTimeVeto" value="3000ns"/> 
            <parameter name="noiseLevelVeto" value="5"/>
            <parameter name="calibrationEnergyVeto" value="(0,10)MeV"/>
            <parameter name="calibrationRangeVeto" value="(0.05,0.50)"/>
</addProcess>
```

For example, for a signal induced by an xray of 5.9keV:

![noise_0](https://github.com/rest-for-physics/connectorslib/assets/106647320/7953ef5f-02f6-4e39-992d-ee673af9b4ba)

The signal processed with `noiseLevelTpc` = 10 is:
![noise_10](https://github.com/rest-for-physics/connectorslib/assets/106647320/aa0b8072-da32-4395-9fe2-1525f6ea5d11)

And, with `noiseLevelTpc`= 50 is:
![noise_50](https://github.com/rest-for-physics/connectorslib/assets/106647320/7f1b0595-fe3f-474d-909b-18b5b3793e6a)

