### PR TITLE
Improvements and fixes to REST_Connectors_RawReadoutChannelActivity macro

### DIFF
--- a/macros/REST_Connectors_RawReadoutChannelActivity.C
+++ b/macros/REST_Connectors_RawReadoutChannelActivity.C
@@ -5,12 +5,8 @@
 //***
 //**********************************************************************************************************
 
-Int_t REST_Connectors_RawReadoutChannelActivity(
-    std::string fName,
-    TString fReadout,
-    std::string cut="",
-    Int_t nEntries=0
-) {
+Int_t REST_Connectors_RawReadoutChannelActivity(std::string fName, TString fReadout, std::string cut = "",
+                                                Int_t nEntries = 0) {
     //// Readout ////
     std::cout << "Opening readout file: " << fReadout << std::endl;
     TFile* f = new TFile(fReadout);
@@ -33,9 +29,9 @@ Int_t REST_Connectors_RawReadoutChannelActivity(
 
     std::cout << "Getting modules..." << std::endl;
     std::vector<TRestDetectorReadoutModule*> modules;
-    for (size_t p=0; p<readout->GetNumberOfReadoutPlanes(); p++) {
+    for (size_t p = 0; p < readout->GetNumberOfReadoutPlanes(); p++) {
         TRestDetectorReadoutPlane* plane = readout->GetReadoutPlane(p);
-        for (size_t m=0; m<plane->GetNumberOfModules(); m++) {
+        for (size_t m = 0; m < plane->GetNumberOfModules(); m++) {
             modules.push_back(plane->GetModule(m));
         }
     }
@@ -45,23 +41,27 @@ Int_t REST_Connectors_RawReadoutChannelActivity(
     std::vector<TH2D*> hChannelActivityIDTime;
     for (size_t m = 0; m < modules.size(); m++) {
         auto module = modules[m];
-        hChannelActivityID.push_back(new TH1D("", Form("Readout ID - module %zu", m), module->GetMaxDaqID()-module->GetMinDaqID(), module->GetMinDaqID(), module->GetMaxDaqID()));
-        hChannelActivityIDTime.push_back(new TH2D("", Form("ChAct ID - Time - module %zu", m), 100, startTimeStamp, endTimeStamp, module->GetMaxDaqID()-module->GetMinDaqID(), module->GetMinDaqID(), module->GetMaxDaqID()));
+        hChannelActivityID.push_back(new TH1D("", Form("Readout ID - module %zu", m),
+                                              module->GetMaxDaqID() - module->GetMinDaqID(),
+                                              module->GetMinDaqID(), module->GetMaxDaqID()));
+        hChannelActivityIDTime.push_back(new TH2D(
+            "", Form("ChAct ID - Time - module %zu", m), 100, startTimeStamp, endTimeStamp,
+            module->GetMaxDaqID() - module->GetMinDaqID(), module->GetMinDaqID(), module->GetMaxDaqID()));
     }
 
     std::cout << "Looping over entries..." << std::endl;
     // Loop over entries and signals per entry
     TRestRawSignalEvent* fRawSignalEvent = new TRestRawSignalEvent();
     Int_t nEntriesToProcess = run->GetEntries();
-    if (nEntries > 0 && nEntries < run->GetEntries())
-        nEntriesToProcess = nEntries;
-    
+    if (nEntries > 0 && nEntries < run->GetEntries()) nEntriesToProcess = nEntries;
+
     TRestAnalysisTree* analysisTree = run->GetAnalysisTree();
     for (Int_t i = 0; i < nEntriesToProcess; i++) {
         run->GetEntry(i);
-        auto progressPercentage= (i+1)*100./nEntriesToProcess;
-        if (i==0 || i%1000==0 || i==nEntriesToProcess-1)
-            std::cout << "\rEntry: " << i << " / " << nEntriesToProcess << " (" << progressPercentage << "%)" << std::flush;
+        auto progressPercentage = (i + 1) * 100. / nEntriesToProcess;
+        if (i == 0 || i % 1000 == 0 || i == nEntriesToProcess - 1)
+            std::cout << "\rEntry: " << i << " / " << nEntriesToProcess << " (" << progressPercentage << "%)"
+                      << std::flush;
 
         if (cut != "") {
             if (!analysisTree->EvaluateCuts(cut.c_str())) {
@@ -74,7 +74,7 @@ Int_t REST_Connectors_RawReadoutChannelActivity(
             TRestRawSignal* sigA = fRawSignalEvent->GetSignal(k);
             auto signalID = sigA->GetID();
             // find the module corresponding to the signal ID
-            for (size_t m=0; m<modules.size(); m++) {
+            for (size_t m = 0; m < modules.size(); m++) {
                 auto module = modules[m];
                 if (module->IsDaqIDInside(signalID)) {
                     hChannelActivityID[m]->Fill(signalID);
@@ -92,7 +92,7 @@ Int_t REST_Connectors_RawReadoutChannelActivity(
         hChannelActivityID[m]->SetFillColor(4);
         hChannelActivityID[m]->Draw("histo");
         hChannelActivityID[m]->GetXaxis()->SetTitle(Form("ID readout channel - Module %zu", m));
-        
+
         // Generate TGraph of readout channel activity ordered by its position in X and Y
         TGraph* gX = new TGraph();
         TGraph* gY = new TGraph();
@@ -114,23 +114,24 @@ Int_t REST_Connectors_RawReadoutChannelActivity(
         TCanvas* cX2 = new TCanvas(Form("cX2_module%zu", m));
         gX->SetFillColor(38);
         gX->SetMarkerColor(4);
-        //gX->SetMarkerSize(0.2);
+        // gX->SetMarkerSize(0.2);
         gX->Draw("APB");
         gX->GetXaxis()->SetTitle(Form("X readout channel (mm) - Module %zu", m));
-        
+
         TCanvas* cY2 = new TCanvas(Form("cY2_module%zu", m));
         gY->SetFillColor(38);
         gY->SetMarkerColor(4);
-        //gY->SetMarkerSize(0.2);
+        // gY->SetMarkerSize(0.2);
         gY->Draw("APB");
         gY->GetXaxis()->SetTitle(Form("Y readout channel (mm) - Module %zu", m));
 
-
         // Generate 2D histogram of readout channel activity in time ordered by its position in X and Y
-        TH2D* hChannelActivityXTime = new TH2D("", Form("ChAct X - Time - module %zu", m), 100, startTimeStamp, endTimeStamp, mod->GetNumberOfChannels()/2, mod->GetOrigin().X(),
-                            mod->GetOrigin().X() + mod->GetSize().X());
-        TH2D* hChannelActivityYTime = new TH2D("", Form("ChAct Y - Time - module %zu", m),100, startTimeStamp, endTimeStamp, mod->GetNumberOfChannels()/2, mod->GetOrigin().Y(),
-                            mod->GetOrigin().Y() + mod->GetSize().Y());
+        TH2D* hChannelActivityXTime = new TH2D(
+            "", Form("ChAct X - Time - module %zu", m), 100, startTimeStamp, endTimeStamp,
+            mod->GetNumberOfChannels() / 2, mod->GetOrigin().X(), mod->GetOrigin().X() + mod->GetSize().X());
+        TH2D* hChannelActivityYTime = new TH2D(
+            "", Form("ChAct Y - Time - module %zu", m), 100, startTimeStamp, endTimeStamp,
+            mod->GetNumberOfChannels() / 2, mod->GetOrigin().Y(), mod->GetOrigin().Y() + mod->GetSize().Y());
         for (int bx = 1; bx <= hChannelActivityIDTime[m]->GetNbinsY(); bx++) {
             int signalID = hChannelActivityIDTime[m]->GetYaxis()->GetBinCenter(bx);
             auto x = readout->GetX(signalID);
@@ -158,7 +159,6 @@ Int_t REST_Connectors_RawReadoutChannelActivity(
         hChannelActivityYTime->GetYaxis()->SetTitle(Form("Y readout channel (mm) - Module %zu", m));
         hChannelActivityYTime->GetXaxis()->SetTitle("Time");
         hChannelActivityYTime->GetXaxis()->SetTimeDisplay(1);
-
     }
 
     return 0;

--- a/macros/REST_Connectors_RawReadoutChannelActivity.C
+++ b/macros/REST_Connectors_RawReadoutChannelActivity.C
@@ -5,8 +5,14 @@
 //***
 //**********************************************************************************************************
 
-Int_t REST_Connectors_RawReadoutChannelActivity(string fName, TString fReadout) {
+Int_t REST_Connectors_RawReadoutChannelActivity(
+    std::string fName,
+    TString fReadout,
+    std::string cut="",
+    Int_t nEntries=0
+) {
     //// Readout ////
+    std::cout << "Opening readout file: " << fReadout << std::endl;
     TFile* f = new TFile(fReadout);
     TRestDetectorReadout* readout = NULL;
 
@@ -20,52 +26,140 @@ Int_t REST_Connectors_RawReadoutChannelActivity(string fName, TString fReadout) 
     }
     delete key;
     readout->PrintMetadata(2);
-
-    // Histogram size form readout dimensions
-    TH1D* hChannelActivityX = new TH1D("", "Readout X", readout->GetNumberOfChannels() / 2, 0,
-                                       readout->GetReadoutModuleWithID(0)->GetModuleSizeX());
-    TH1D* hChannelActivityY = new TH1D("", "Readout Y", readout->GetNumberOfChannels() / 2, 0,
-                                       readout->GetReadoutModuleWithID(0)->GetModuleSizeY());
-    TH1D* hChannelActivityID =
-        new TH1D("", "Readout ID", readout->GetNumberOfChannels(), 0, readout->GetNumberOfChannels());
-
+    std::cout << "Opening TRestRun file: " << fName << std::endl;
     TRestRun* run = new TRestRun(fName);
-    TRestRawSignalEvent* fRawSignalEvent = new TRestRawSignalEvent();
+    double startTimeStamp = run->GetStartTimestamp();
+    double endTimeStamp = run->GetEndTimestamp();
 
+    std::cout << "Getting modules..." << std::endl;
+    std::vector<TRestDetectorReadoutModule*> modules;
+    for (size_t p=0; p<readout->GetNumberOfReadoutPlanes(); p++) {
+        TRestDetectorReadoutPlane* plane = readout->GetReadoutPlane(p);
+        for (size_t m=0; m<plane->GetNumberOfModules(); m++) {
+            modules.push_back(plane->GetModule(m));
+        }
+    }
+
+    std::cout << "Creating histograms..." << std::endl;
+    std::vector<TH1D*> hChannelActivityID;
+    std::vector<TH2D*> hChannelActivityIDTime;
+    for (size_t m = 0; m < modules.size(); m++) {
+        auto module = modules[m];
+        hChannelActivityID.push_back(new TH1D("", Form("Readout ID - module %zu", m), module->GetMaxDaqID()-module->GetMinDaqID(), module->GetMinDaqID(), module->GetMaxDaqID()));
+        hChannelActivityIDTime.push_back(new TH2D("", Form("ChAct ID - Time - module %zu", m), 100, startTimeStamp, endTimeStamp, module->GetMaxDaqID()-module->GetMinDaqID(), module->GetMinDaqID(), module->GetMaxDaqID()));
+    }
+
+    std::cout << "Looping over entries..." << std::endl;
     // Loop over entries and signals per entry
-    for (Int_t i = 0; i < run->GetEntries(); i++) {
+    TRestRawSignalEvent* fRawSignalEvent = new TRestRawSignalEvent();
+    Int_t nEntriesToProcess = run->GetEntries();
+    if (nEntries > 0 && nEntries < run->GetEntries())
+        nEntriesToProcess = nEntries;
+    
+    TRestAnalysisTree* analysisTree = run->GetAnalysisTree();
+    for (Int_t i = 0; i < nEntriesToProcess; i++) {
         run->GetEntry(i);
-        fRawSignalEvent = (TRestRawSignalEvent*)run->GetInputEvent();
+        auto progressPercentage= (i+1)*100./nEntriesToProcess;
+        if (i==0 || i%1000==0 || i==nEntriesToProcess-1)
+            std::cout << "\rEntry: " << i << " / " << nEntriesToProcess << " (" << progressPercentage << "%)" << std::flush;
 
+        if (cut != "") {
+            if (!analysisTree->EvaluateCuts(cut.c_str())) {
+                continue;
+            }
+        }
+
+        fRawSignalEvent = (TRestRawSignalEvent*)run->GetInputEvent();
         for (int k = 0; k < fRawSignalEvent->GetNumberOfSignals(); k++) {
             TRestRawSignal* sigA = fRawSignalEvent->GetSignal(k);
-            hChannelActivityID->Fill(sigA->GetID());
-            double xA = readout->GetX(sigA->GetID());
-            double yA = readout->GetY(sigA->GetID());
-
-            if (!isnan(xA)) {
-                hChannelActivityX->Fill(xA);
-            }
-            if (!isnan(yA)) {
-                hChannelActivityY->Fill(yA);
+            auto signalID = sigA->GetID();
+            // find the module corresponding to the signal ID
+            for (size_t m=0; m<modules.size(); m++) {
+                auto module = modules[m];
+                if (module->IsDaqIDInside(signalID)) {
+                    hChannelActivityID[m]->Fill(signalID);
+                    hChannelActivityIDTime[m]->Fill(fRawSignalEvent->GetTimeStamp(), signalID);
+                }
             }
         }
     }
-    delete run;
-    delete fRawSignalEvent;
 
-    // Plot readout channel activity
-    TCanvas* cX1 = new TCanvas();
-    hChannelActivityX->Draw("histo");
-    hChannelActivityX->GetXaxis()->SetTitle("X readout channel");
+    std::cout << "Generating and plotting histograms..." << std::endl;
+    for (size_t m = 0; m < modules.size(); m++) {
+        auto mod = modules[m];
+        // Plot readout channel activity
+        TCanvas* cID = new TCanvas(Form("cID_module%zu", m));
+        hChannelActivityID[m]->SetFillColor(4);
+        hChannelActivityID[m]->Draw("histo");
+        hChannelActivityID[m]->GetXaxis()->SetTitle(Form("ID readout channel - Module %zu", m));
+        
+        // Generate TGraph of readout channel activity ordered by its position in X and Y
+        TGraph* gX = new TGraph();
+        TGraph* gY = new TGraph();
+        gX->SetTitle(Form("Readout X - module %zu", m));
+        gY->SetTitle(Form("Readout Y - module %zu", m));
+        for (int bx = 1; bx <= hChannelActivityID[m]->GetNbinsX(); bx++) {
+            int signalID = hChannelActivityID[m]->GetBinCenter(bx);
+            auto x = readout->GetX(signalID);
+            auto y = readout->GetY(signalID);
+            auto counts = hChannelActivityID[m]->GetBinContent(bx);
+            if (!isnan(x)) {
+                gX->AddPoint(x, counts);
+            }
+            if (!isnan(y)) {
+                gY->AddPoint(y, counts);
+            }
+        }
 
-    TCanvas* cY1 = new TCanvas();
-    hChannelActivityY->Draw("histo");
-    hChannelActivityY->GetXaxis()->SetTitle("Y readout channel");
+        TCanvas* cX2 = new TCanvas(Form("cX2_module%zu", m));
+        gX->SetFillColor(38);
+        gX->SetMarkerColor(4);
+        //gX->SetMarkerSize(0.2);
+        gX->Draw("APB");
+        gX->GetXaxis()->SetTitle(Form("X readout channel (mm) - Module %zu", m));
+        
+        TCanvas* cY2 = new TCanvas(Form("cY2_module%zu", m));
+        gY->SetFillColor(38);
+        gY->SetMarkerColor(4);
+        //gY->SetMarkerSize(0.2);
+        gY->Draw("APB");
+        gY->GetXaxis()->SetTitle(Form("Y readout channel (mm) - Module %zu", m));
 
-    TCanvas* cID = new TCanvas();
-    hChannelActivityID->Draw("histo");
-    hChannelActivityID->GetXaxis()->SetTitle("ID readout channel");
+
+        // Generate 2D histogram of readout channel activity in time ordered by its position in X and Y
+        TH2D* hChannelActivityXTime = new TH2D("", Form("ChAct X - Time - module %zu", m), 100, startTimeStamp, endTimeStamp, mod->GetNumberOfChannels()/2, mod->GetOrigin().X(),
+                            mod->GetOrigin().X() + mod->GetSize().X());
+        TH2D* hChannelActivityYTime = new TH2D("", Form("ChAct Y - Time - module %zu", m),100, startTimeStamp, endTimeStamp, mod->GetNumberOfChannels()/2, mod->GetOrigin().Y(),
+                            mod->GetOrigin().Y() + mod->GetSize().Y());
+        for (int bx = 1; bx <= hChannelActivityIDTime[m]->GetNbinsY(); bx++) {
+            int signalID = hChannelActivityIDTime[m]->GetYaxis()->GetBinCenter(bx);
+            auto x = readout->GetX(signalID);
+            auto y = readout->GetY(signalID);
+            for (int tx = 1; tx <= hChannelActivityIDTime[m]->GetNbinsX(); tx++) {
+                double time = hChannelActivityIDTime[m]->GetXaxis()->GetBinCenter(tx);
+                double counts = hChannelActivityIDTime[m]->GetBinContent(tx, bx);
+                if (!isnan(x) && counts > 0) {
+                    hChannelActivityXTime->Fill(time, x, counts);
+                }
+                if (!isnan(y) && counts > 0) {
+                    hChannelActivityYTime->Fill(time, y, counts);
+                }
+            }
+        }
+
+        TCanvas* cCAX = new TCanvas(Form("cCAX_module%zu", m));
+        hChannelActivityXTime->Draw("histo colz");
+        hChannelActivityXTime->GetYaxis()->SetTitle(Form("X readout channel (mm) - Module %zu", m));
+        hChannelActivityXTime->GetXaxis()->SetTitle("Time");
+        hChannelActivityXTime->GetXaxis()->SetTimeDisplay(1);
+
+        TCanvas* cCAY = new TCanvas(Form("cCAY_module%zu", m));
+        hChannelActivityYTime->Draw("histo colz");
+        hChannelActivityYTime->GetYaxis()->SetTitle(Form("Y readout channel (mm) - Module %zu", m));
+        hChannelActivityYTime->GetXaxis()->SetTitle("Time");
+        hChannelActivityYTime->GetXaxis()->SetTimeDisplay(1);
+
+    }
 
     return 0;
 }


### PR DESCRIPTION
![AlvaroEzq](https://img.shields.io/badge/PR_submitted_by%3A-AlvaroEzq-blue?logo=) ![Medium: 126](https://img.shields.io/badge/PR_Size-Medium%3A_126-orange?logo=) [![](https://gitlab.cern.ch/rest-for-physics/framework/badges/aezq_fixMacro/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/framework/-/commits/aezq_fixMacro) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=rest-for-physics&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->  

- Update the methods of TRestDetectorReadout to the correct ones in REST v2.4
- Plot for every module in the readout
- Optimize by extracting only the signal ID and timestamp in the entries loop and converting this to X and Y position afterwards.
- Helpfull new parameters:
   - `cut` : apply cut to observables to filter the events used
   - `nEntries` : number of entries to be used, as it can be very slow when there is a big number of events to process 