### PR TITLE
TRestGeant4ToDetectorHitsProcess add a gain factor for each added volume

### DIFF
--- a/inc/TRestGeant4ToDetectorHitsProcess.h
+++ b/inc/TRestGeant4ToDetectorHitsProcess.h
@@ -31,6 +31,13 @@
 #include <string>
 #include <vector>
 
+struct VolumeProperties {
+      Int_t volumeID;
+      TString volumeName;
+      REST_HitType hitType;
+      Double_t gain;
+};
+
 /// A process to transform a *TRestGeant4Event* into a *TRestDetectorHitsEvent*.
 class TRestGeant4ToDetectorHitsProcess : public TRestEventProcess {
    private:
@@ -43,13 +50,17 @@ class TRestGeant4ToDetectorHitsProcess : public TRestEventProcess {
     /// A pointer to the output TRestDetectorHitsEvent
     TRestDetectorHitsEvent* fHitsEvent;  //!
 
-    /// The volume ids from the volumes selected for transfer to TRestDetectorHitsEvent
-    std::vector<Int_t> fVolumeId;  //!
-
     /// The geometry volume names to be transferred to TRestDetectorHitsEvent
     std::vector<TString> fVolumeSelection;
 
-    std::map<std::string, REST_HitType> fHitTypes;  //!
+    /// The hit type associated to each selected volume (same order as fVolumeSelection).
+    std::vector<REST_HitType> fVolumeHitType;
+
+    /// The gain applied to the energy deposition of each hit in the selected volumes (same order as fVolumeSelection).
+    std::vector<Double_t> fVolumeGain;
+
+    /// Vector of volumes selection and its properties. Set on InitProcess and used for easy and fast access when processing the event.
+    std::vector<VolumeProperties> fVolumeProperties;  //!
 
     void InitFromConfigFile() override;
 
@@ -84,7 +95,7 @@ class TRestGeant4ToDetectorHitsProcess : public TRestEventProcess {
     // Destructor
     ~TRestGeant4ToDetectorHitsProcess() override;
 
-    ClassDefOverride(TRestGeant4ToDetectorHitsProcess, 2);  // Transform a TRestGeant4Event event to a
+    ClassDefOverride(TRestGeant4ToDetectorHitsProcess, 3);  // Transform a TRestGeant4Event event to a
                                                             // TRestDetectorHitsEvent (hits-collection event)
 };
 

--- a/inc/TRestGeant4ToDetectorHitsProcess.h
+++ b/inc/TRestGeant4ToDetectorHitsProcess.h
@@ -32,10 +32,10 @@
 #include <vector>
 
 struct VolumeProperties {
-      Int_t volumeID;
-      TString volumeName;
-      REST_HitType hitType;
-      Double_t gain;
+    Int_t volumeID;
+    TString volumeName;
+    REST_HitType hitType;
+    Double_t gain;
 };
 
 /// A process to transform a *TRestGeant4Event* into a *TRestDetectorHitsEvent*.
@@ -56,10 +56,12 @@ class TRestGeant4ToDetectorHitsProcess : public TRestEventProcess {
     /// The hit type associated to each selected volume (same order as fVolumeSelection).
     std::vector<REST_HitType> fVolumeHitType;
 
-    /// The gain applied to the energy deposition of each hit in the selected volumes (same order as fVolumeSelection).
+    /// The gain applied to the energy deposition of each hit in the selected volumes (same order as
+    /// fVolumeSelection).
     std::vector<Double_t> fVolumeGain;
 
-    /// Vector of volumes selection and its properties. Set on InitProcess and used for easy and fast access when processing the event.
+    /// Vector of volumes selection and its properties. Set on InitProcess and used for easy and fast access
+    /// when processing the event.
     std::vector<VolumeProperties> fVolumeProperties;  //!
 
     void InitFromConfigFile() override;

--- a/src/TRestGeant4ToDetectorHitsProcess.cxx
+++ b/src/TRestGeant4ToDetectorHitsProcess.cxx
@@ -140,19 +140,36 @@ void TRestGeant4ToDetectorHitsProcess::InitProcess() {
     fGeant4Metadata = GetMetadata<TRestGeant4Metadata>();
 
     for (const auto& userVolume : fVolumeSelection) {
-        if (fGeant4Metadata->GetActiveVolumeID(userVolume) >= 0) {
-            fVolumeId.push_back(fGeant4Metadata->GetActiveVolumeID(userVolume));
+        auto volId = fGeant4Metadata->GetActiveVolumeID(userVolume);
+        if (volId >= 0) {
+            VolumeProperties properties{volId, userVolume, REST_HitType::XYZ, 1.0}; // default values
+            for (size_t i = 0; i < fVolumeSelection.size(); i++) {
+                if (fVolumeSelection[i] == userVolume) {
+                    properties.hitType = fVolumeHitType[i];
+                    properties.gain = fVolumeGain[i];
+                    break;
+                }
+            }
+            fVolumeProperties.push_back(properties);
         } else if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Warning)
             cout << "TRestGeant4ToDetectorHitsProcess. volume name : " << userVolume
                  << " not found and will not be added." << endl;
     }
 
-    sort(fVolumeId.begin(), fVolumeId.end());
-    fVolumeId.erase(unique(fVolumeId.begin(), fVolumeId.end()), fVolumeId.end());
+    // sort fVolumeProperties by volumeID for faster access when processing the event
+    sort(fVolumeProperties.begin(), fVolumeProperties.end(), [](const VolumeProperties& a, const VolumeProperties& b) {
+        return a.volumeID < b.volumeID;
+    });
+    // erase duplicate volumeIDs in fVolumeProperties (if any)
+    fVolumeProperties.erase(unique(fVolumeProperties.begin(), fVolumeProperties.end(),
+                                  [](const VolumeProperties& a, const VolumeProperties& b) {
+                                      return a.volumeID == b.volumeID;
+                                  }),
+                             fVolumeProperties.end());
 
-    for (size_t i = 0; i < fVolumeId.size(); i++) {
-        RESTDebug << "TRestGeant4ToDetectorHitsProcess. Volume id : " << fVolumeId[i]
-                  << " name : " << fGeant4Metadata->GetActiveVolumeName(fVolumeId[i]) << RESTendl;
+    for (size_t i = 0; i < fVolumeProperties.size(); i++) {
+        RESTDebug << "TRestGeant4ToDetectorHitsProcess. Volume id : " << fVolumeProperties[i].volumeID
+                  << " name : " << fGeant4Metadata->GetActiveVolumeName(fVolumeProperties[i].volumeID) << RESTendl;
     }
 
     RESTDebug << "Active volumes available in TRestGeant4Metadata" << RESTendl;
@@ -174,11 +191,11 @@ void TRestGeant4ToDetectorHitsProcess::InitProcess() {
         RESTDebug << " " << RESTendl;
     }
 
-    if (!fVolumeSelection.empty() && fVolumeSelection.size() != fVolumeId.size())
+    if (!fVolumeSelection.empty() && fVolumeSelection.size() != fVolumeProperties.size())
         RESTWarning << "TRestGeant4ToDetectorHitsProcess. Not all volumes were properly identified!"
                     << RESTendl;
 
-    if (!fVolumeId.empty()) {
+    if (!fVolumeProperties.empty()) {
         RESTDebug << "TRestGeant4HitsProcess volumes identified : ";
         RESTDebug << "---------------------------------------" << RESTendl;
         if (fVolumeSelection.empty())
@@ -230,18 +247,22 @@ TRestEvent* TRestGeant4ToDetectorHitsProcess::ProcessEvent(TRestEvent* inputEven
                      << endl;
                 exit(1);
             }
-            if (fVolumeId.empty()) {
+            if (fVolumeProperties.empty()) {
                 // if no volume is selected, all hits are added
                 fHitsEvent->AddHit(position.X(), position.Y(), position.Z(), energy, time);
             } else {
-                const string volumeName = hits.GetVolumeName(i).Data();
+                const TString volumeName = hits.GetVolumeName(i);
                 const auto volumeId = fGeant4Metadata->GetActiveVolumeID(volumeName);
 
                 // cout << "volumeName : " << volumeName << " volumeId : " << volumeId << endl;
-                if (find(fVolumeId.begin(), fVolumeId.end(), volumeId) != fVolumeId.end()) {
-                    const REST_HitType type = fHitTypes.at(volumeName);
+                auto it = find_if(fVolumeProperties.begin(), fVolumeProperties.end(),
+                                  [volumeId](const VolumeProperties& vp) { return vp.volumeID == volumeId; });
+                if (it != fVolumeProperties.end()) {
+                    const auto& properties = *it;
+                    const REST_HitType type = properties.hitType;
+                    const Double_t gain = properties.gain;
 
-                    fHitsEvent->AddHit(position, energy, time, type);
+                    fHitsEvent->AddHit(position, energy * gain, time, type);
                 }
             }
         }
@@ -269,6 +290,8 @@ void TRestGeant4ToDetectorHitsProcess::InitFromConfigFile() {
     }
 
     set<string> volumesToAdd;
+    map<string, Double_t> volumeGain;
+    map<string, REST_HitType> volumeHitType;
     TiXmlElement* volumeDefinition = GetElement("volume");
     if (volumeDefinition == nullptr) {
         volumeDefinition = GetElement("addVolume");
@@ -281,6 +304,7 @@ void TRestGeant4ToDetectorHitsProcess::InitFromConfigFile() {
     while (volumeDefinition != nullptr) {
         const auto userVolume = GetFieldValue("name", volumeDefinition);
         const auto typeName = GetFieldValue("type", volumeDefinition);
+        const Double_t gain = StringToDouble(GetParameter("gain", volumeDefinition, "1.0"));
         REST_HitType type = XYZ;
         if (typeName == "veto") {
             type = VETO;
@@ -305,11 +329,13 @@ void TRestGeant4ToDetectorHitsProcess::InitFromConfigFile() {
             }
             for (const auto& physicalVolume : physicalVolumes) {
                 volumesToAdd.insert(physicalVolume.Data());
-                fHitTypes[physicalVolume.Data()] = type;
+                volumeHitType[physicalVolume.Data()] = type;
+                volumeGain[physicalVolume.Data()] = gain;
             }
         } else {
             volumesToAdd.insert(userVolume);
-            fHitTypes[userVolume] = type;
+            volumeHitType[userVolume] = type;
+            volumeGain[userVolume] = gain;
         }
 
         volumeDefinition = GetNextElement(volumeDefinition);
@@ -318,6 +344,24 @@ void TRestGeant4ToDetectorHitsProcess::InitFromConfigFile() {
     for (const auto& volume : volumesToAdd) {
         if (find(fVolumeSelection.begin(), fVolumeSelection.end(), volume) == fVolumeSelection.end()) {
             fVolumeSelection.emplace_back(volume);
+
+            // hit type should be in volumeHitType. Anyways, set default hit type of XYZ if not found
+            if (volumeHitType.find(volume) != volumeHitType.end()) {
+                fVolumeHitType.push_back(volumeHitType[volume]);
+            } else {
+                RESTWarning << "TRestGeant4ToDetectorHitsProcess. No hit type defined for volume " << volume
+                            << ". Using default hit type XYZ" << RESTendl;
+                fVolumeHitType.push_back(XYZ);
+            }
+
+            // volume should be in volumeGain. Anyways, set deafult gain of 1.0 if not found
+            if (volumeGain.find(volume) != volumeGain.end()) {
+                fVolumeGain.push_back(volumeGain[volume]);
+            } else {
+                RESTWarning << "TRestGeant4ToDetectorHitsProcess. No gain defined for volume " << volume
+                            << ". Using default gain of 1.0" << RESTendl;
+                fVolumeGain.push_back(1.0);
+            }
         }
     }
 }
@@ -328,8 +372,12 @@ void TRestGeant4ToDetectorHitsProcess::InitFromConfigFile() {
 void TRestGeant4ToDetectorHitsProcess::PrintMetadata() {
     BeginPrintProcess();
 
-    for (const auto& volume : fVolumeSelection) {
-        RESTMetadata << "Volume added : " << volume << RESTendl;
+    for (size_t i = 0; i < fVolumeSelection.size(); i++) {
+        const auto& volume = fVolumeSelection[i];
+        const auto& gain = fVolumeGain[i];
+        const auto& hitType = fVolumeHitType[i];
+        RESTMetadata << "Volume added : " << volume << " with gain : " << gain
+                        << " and hit type : " << hitType << RESTendl;
     }
 
     EndPrintProcess();

--- a/src/TRestGeant4ToDetectorHitsProcess.cxx
+++ b/src/TRestGeant4ToDetectorHitsProcess.cxx
@@ -43,8 +43,10 @@
 ///
 /// ## Advanced options
 /// There are a couple of additional parameters that can be defined for each volume:
-/// * **type**: The hit type associated to the selected volume. Useful for veto volumes by setting it to `veto`. Otherwise, the default value is `XYZ`.
-/// * **gain**: A gain factor applied to the energy deposition of each hit in the selected volume. Default is 1.
+/// * **type**: The hit type associated to the selected volume. Useful for veto volumes by setting it to
+/// `veto`. Otherwise, the default value is `XYZ`.
+/// * **gain**: A gain factor applied to the energy deposition of each hit in the selected volume. Default
+/// is 1.
 ///
 /// For example:
 /// \code

--- a/src/TRestGeant4ToDetectorHitsProcess.cxx
+++ b/src/TRestGeant4ToDetectorHitsProcess.cxx
@@ -25,13 +25,13 @@
 /// TRestGeant4Metadata) that will be transferred to the TRestDetectorHitsEvent by
 /// using the `<volume` key inside the process definition.
 ///
+/// ## Basic usage
 /// The following example shows how to include the process into
 /// `TRestProcessRunner` RML definition. In this particular example we
 /// extract hits from `gas` and `vessel` volumes defined in the geometry.
 /// Any other hits will be ignored.
 ///
 /// \code
-///
 /// <addProcess type="TRestGeant4ToDetectorHitsProcess" name="g4ToHits" value="ON">
 ///     <volume name="gas"/>
 ///     <volume name="vessel"/>
@@ -41,6 +41,19 @@
 /// If no volumes are defined using the `<volume` key, **all volumes will
 /// be active**, and all hits will be transferred to the TRestDetectorHitsEvent output.
 ///
+/// ## Advanced options
+/// There are a couple of additional parameters that can be defined for each volume:
+/// * **type**: The hit type associated to the selected volume. Useful for veto volumes by setting it to `veto`. Otherwise, the default value is `XYZ`.
+/// * **gain**: A gain factor applied to the energy deposition of each hit in the selected volume. Default is 1.
+///
+/// For example:
+/// \code
+/// <addProcess type="TRestGeant4ToDetectorHitsProcess" name="g4ToHits" value="ON">
+///     <volume name="driftGas"/> <!-- default hit type is XYZ and gain is 1 -->
+///     <volume name="transferGas" gain="0.1"/>
+///     <volume name="scintillator" type="veto"/>
+/// </addProcess>
+/// \endcode
 ///--------------------------------------------------------------------------
 ///
 /// RESTsoft - Software for Rare Event Searches with TPCs

--- a/src/TRestGeant4ToDetectorHitsProcess.cxx
+++ b/src/TRestGeant4ToDetectorHitsProcess.cxx
@@ -142,7 +142,7 @@ void TRestGeant4ToDetectorHitsProcess::InitProcess() {
     for (const auto& userVolume : fVolumeSelection) {
         auto volId = fGeant4Metadata->GetActiveVolumeID(userVolume);
         if (volId >= 0) {
-            VolumeProperties properties{volId, userVolume, REST_HitType::XYZ, 1.0}; // default values
+            VolumeProperties properties{volId, userVolume, REST_HitType::XYZ, 1.0};  // default values
             for (size_t i = 0; i < fVolumeSelection.size(); i++) {
                 if (fVolumeSelection[i] == userVolume) {
                     properties.hitType = fVolumeHitType[i];
@@ -157,19 +157,18 @@ void TRestGeant4ToDetectorHitsProcess::InitProcess() {
     }
 
     // sort fVolumeProperties by volumeID for faster access when processing the event
-    sort(fVolumeProperties.begin(), fVolumeProperties.end(), [](const VolumeProperties& a, const VolumeProperties& b) {
-        return a.volumeID < b.volumeID;
-    });
+    sort(fVolumeProperties.begin(), fVolumeProperties.end(),
+         [](const VolumeProperties& a, const VolumeProperties& b) { return a.volumeID < b.volumeID; });
     // erase duplicate volumeIDs in fVolumeProperties (if any)
-    fVolumeProperties.erase(unique(fVolumeProperties.begin(), fVolumeProperties.end(),
-                                  [](const VolumeProperties& a, const VolumeProperties& b) {
-                                      return a.volumeID == b.volumeID;
-                                  }),
-                             fVolumeProperties.end());
+    fVolumeProperties.erase(
+        unique(fVolumeProperties.begin(), fVolumeProperties.end(),
+               [](const VolumeProperties& a, const VolumeProperties& b) { return a.volumeID == b.volumeID; }),
+        fVolumeProperties.end());
 
     for (size_t i = 0; i < fVolumeProperties.size(); i++) {
         RESTDebug << "TRestGeant4ToDetectorHitsProcess. Volume id : " << fVolumeProperties[i].volumeID
-                  << " name : " << fGeant4Metadata->GetActiveVolumeName(fVolumeProperties[i].volumeID) << RESTendl;
+                  << " name : " << fGeant4Metadata->GetActiveVolumeName(fVolumeProperties[i].volumeID)
+                  << RESTendl;
     }
 
     RESTDebug << "Active volumes available in TRestGeant4Metadata" << RESTendl;
@@ -377,7 +376,7 @@ void TRestGeant4ToDetectorHitsProcess::PrintMetadata() {
         const auto& gain = fVolumeGain[i];
         const auto& hitType = fVolumeHitType[i];
         RESTMetadata << "Volume added : " << volume << " with gain : " << gain
-                        << " and hit type : " << hitType << RESTendl;
+                     << " and hit type : " << hitType << RESTendl;
     }
 
     EndPrintProcess();


### PR DESCRIPTION
![AlvaroEzq](https://badgen.net/badge/PR%20submitted%20by%3A/AlvaroEzq/blue) ![Ok: 84](https://badgen.net/badge/PR%20Size/Ok%3A%2084/green) [![](https://gitlab.cern.ch/rest-for-physics/framework/badges/aezq_volumeGain/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/framework/-/commits/aezq_volumeGain) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=rest-for-physics&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->  

Add the possibility to apply a gain factor to the energy of the hits based on the volume.

This is useful, for example, in the case of TREX-DM where the hits in the transfer and drift are detected with different gain.

As there was already the property of the hit type, I decided to reorganize the code to enclose the different properties that are set to each added volume together. Also, it should make the process faster (maybe it's negligible). 